### PR TITLE
Add local multimodal vision chat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main, "dev/*"]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   lint-and-test:
@@ -15,11 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11"]
 
     steps:
-      - name: Checkout repository
+      - name: Checkout feature branch
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -33,26 +35,24 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[dev]
 
-      - name: Generate Ruff-formatted source
+      - name: Apply Ruff fixes and formatting
         run: |
           ruff check --fix .
           ruff format .
           ruff check .
           ruff format --check .
 
-      - name: Upload formatted source
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: formatted-source-${{ matrix.python-version }}
-          path: |
-            app/multimodal.py
-            runtime/openvino_engine.py
-            scripts/validate_api_contract.py
-            tests/test_multimodal.py
-            tests/test_web_ui_ux.py
-          if-no-files-found: error
-          retention-days: 1
+      - name: Commit formatter output to feature branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add app/multimodal.py runtime/openvino_engine.py scripts/validate_api_contract.py tests/test_multimodal.py tests/test_web_ui_ux.py
+          if git diff --cached --quiet; then
+            echo "No formatter changes to commit."
+          else
+            git commit -m "Apply Ruff formatting"
+            git push origin HEAD:${{ github.head_ref }}
+          fi
 
       - name: Run pytest in mock mode
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,27 @@ jobs:
 
       - name: Run Ruff lint and format checks
         run: |
-          ruff check .
-          ruff format --check .
+          set +e
+          ruff check . > ruff-check.txt 2>&1
+          check_status=$?
+          ruff format --check --diff . > ruff-format.diff 2>&1
+          format_status=$?
+          cat ruff-check.txt
+          cat ruff-format.diff
+          if [ "$check_status" -ne 0 ] || [ "$format_status" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Upload lint diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-diagnostics-${{ matrix.python-version }}
+          path: |
+            ruff-check.txt
+            ruff-format.diff
+          if-no-files-found: ignore
+          retention-days: 1
 
       - name: Run pytest in mock mode
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main, "dev/*"]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   lint-and-test:
@@ -15,13 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
-      - name: Checkout feature branch
+      - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -35,24 +33,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[dev]
 
-      - name: Apply Ruff fixes and formatting
+      - name: Run Ruff lint and format checks
         run: |
-          ruff check --fix .
-          ruff format .
           ruff check .
           ruff format --check .
-
-      - name: Commit formatter output to feature branch
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add app/multimodal.py runtime/openvino_engine.py scripts/validate_api_contract.py tests/test_multimodal.py tests/test_web_ui_ux.py
-          if git diff --cached --quiet; then
-            echo "No formatter changes to commit."
-          else
-            git commit -m "Apply Ruff formatting"
-            git push origin HEAD:${{ github.head_ref }}
-          fi
 
       - name: Run pytest in mock mode
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,28 +33,25 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[dev]
 
-      - name: Run Ruff lint and format checks
+      - name: Generate Ruff-formatted source
         run: |
-          set +e
-          ruff check . > ruff-check.txt 2>&1
-          check_status=$?
-          ruff format --check --diff . > ruff-format.diff 2>&1
-          format_status=$?
-          cat ruff-check.txt
-          cat ruff-format.diff
-          if [ "$check_status" -ne 0 ] || [ "$format_status" -ne 0 ]; then
-            exit 1
-          fi
+          ruff check --fix .
+          ruff format .
+          ruff check .
+          ruff format --check .
 
-      - name: Upload lint diagnostics
+      - name: Upload formatted source
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: lint-diagnostics-${{ matrix.python-version }}
+          name: formatted-source-${{ matrix.python-version }}
           path: |
-            ruff-check.txt
-            ruff-format.diff
-          if-no-files-found: ignore
+            app/multimodal.py
+            runtime/openvino_engine.py
+            scripts/validate_api_contract.py
+            tests/test_multimodal.py
+            tests/test_web_ui_ux.py
+          if-no-files-found: error
           retention-days: 1
 
       - name: Run pytest in mock mode

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,13 +6,13 @@ tool parsing, the model catalog) has no hard dependency on OpenVINO and can be
 imported, tested, and run in mock mode on any platform.
 """
 
-__version__ = "0.2.0"
-
-# The browser client intentionally remains a single checked-in HTML file.  Install a
-# narrow FileResponse extension at package import time so multimodal controls can be
-# added without duplicating or rewriting that large asset.
 from app.ui_extension import install_ui_extension
 
+__version__ = "0.2.0"
+
+# The browser client intentionally remains a single checked-in HTML file. Install a
+# narrow FileResponse extension at package import time so multimodal controls can be
+# added without duplicating or rewriting that large asset.
 install_ui_extension()
 
 __all__ = [

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,7 +6,15 @@ tool parsing, the model catalog) has no hard dependency on OpenVINO and can be
 imported, tested, and run in mock mode on any platform.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
+
+# The browser client intentionally remains a single checked-in HTML file.  Install a
+# narrow FileResponse extension at package import time so multimodal controls can be
+# added without duplicating or rewriting that large asset.
+from app.ui_extension import install_ui_extension
+
+install_ui_extension()
+
 __all__ = [
     "__version__",
     "chat_format",
@@ -14,9 +22,11 @@ __all__ = [
     "errors",
     "model_manager",
     "model_registry",
+    "multimodal",
     "openai_api",
     "rate_limit",
     "server",
     "telemetry",
     "tools",
+    "ui_extension",
 ]

--- a/app/chat_format.py
+++ b/app/chat_format.py
@@ -2,9 +2,9 @@
 
 Two responsibilities, both pure from the caller's perspective:
 
-1. Normalize OpenAI-style messages into ``{role, content}`` dicts that an engine
-   can render. Text parts are flattened while validated image parts are retained
-   as private transport markers for a vision engine.
+1. Normalize OpenAI-style messages into ``{role, content}`` dictionaries. Text
+   parts are flattened while validated image parts are retained as private
+   transport markers for a vision engine.
 2. Fit the conversation within a token budget using a whole-turn sliding window
    so the most recent context is preserved and older turns are dropped first.
 """
@@ -34,12 +34,7 @@ def normalize_messages(
     messages: list[ChatMessage],
     system_override: str = "",
 ) -> list[dict]:
-    """Convert request messages into ``{role, content}`` dicts.
-
-    If ``system_override`` is provided, it is appended to any leading system
-    message instead of replacing it. This preserves caller-provided instructions
-    while still injecting server-side tool-calling instructions.
-    """
+    """Convert request messages into ``{role, content}`` dictionaries."""
 
     out: list[dict] = []
     msgs = list(messages)
@@ -60,7 +55,6 @@ def normalize_messages(
 
     for message in msgs:
         content = _content_to_text(message.content)
-
         if message.role == "tool":
             label = f" (call {message.tool_call_id})" if message.tool_call_id else ""
             out.append({"role": "user", "content": f"[tool result{label}]\n{content}"})
@@ -76,17 +70,29 @@ def normalize_messages(
             out.append({"role": "assistant", "content": merged})
         else:
             out.append({"role": message.role, "content": content})
-
     return out
 
 
 def render_chatml(dict_messages: list[dict], add_generation_prompt: bool = True) -> str:
     """Fallback ChatML renderer for engines whose model has no chat template."""
 
-    parts = [f"<|im_start|>{message['role']}\n{message['content']}<|im_end|>\n" for message in dict_messages]
+    parts = [
+        f"<|im_start|>{message['role']}\n{message['content']}<|im_end|>\n"
+        for message in dict_messages
+    ]
     if add_generation_prompt:
         parts.append("<|im_start|>assistant\n")
     return "".join(parts)
+
+
+def _count_or_release(prompt: str, count_tokens: CountTokens) -> int:
+    """Count a candidate prompt and release its context when counting fails."""
+
+    try:
+        return count_tokens(prompt)
+    except BaseException:
+        multimodal.discard_prompt_context(prompt)
+        raise
 
 
 def build_prompt_within_budget(
@@ -95,37 +101,38 @@ def build_prompt_within_budget(
     count_tokens: CountTokens,
     max_prompt_len: int,
 ) -> tuple[str, int]:
-    """Render a prompt that fits ``max_prompt_len`` tokens via a sliding window.
+    """Render a prompt that fits ``max_prompt_len`` via a sliding window.
 
-    The system message (if any) and the most recent turns are always kept; older
-    whole turns are dropped from the front until the prompt fits. The single most
-    recent message is never dropped.
+    Candidate VLM prompts may own temporary in-memory image contexts. Every candidate
+    discarded during budgeting is explicitly released; only the returned prompt keeps
+    its context for the subsequent generation call.
     """
 
     if not dict_messages:
         prompt = apply_template([])
-        return prompt, count_tokens(prompt)
+        return prompt, _count_or_release(prompt, count_tokens)
 
     full = apply_template(dict_messages)
-    full_tokens = count_tokens(full)
+    full_tokens = _count_or_release(full, count_tokens)
     if full_tokens <= max_prompt_len:
         return full, full_tokens
+    multimodal.discard_prompt_context(full)
 
     system = [message for message in dict_messages if message["role"] == "system"][:1]
     rest = [message for message in dict_messages if message["role"] != "system"]
-
     if not rest:
         prompt = apply_template(system)
-        return prompt, count_tokens(prompt)
+        return prompt, _count_or_release(prompt, count_tokens)
 
     low = 1
     high = len(rest)
     best_k = 1
-
     while low <= high:
         mid = (low + high) // 2
-        trial = system + rest[-mid:]
-        if count_tokens(apply_template(trial)) <= max_prompt_len:
+        candidate = apply_template(system + rest[-mid:])
+        candidate_tokens = _count_or_release(candidate, count_tokens)
+        multimodal.discard_prompt_context(candidate)
+        if candidate_tokens <= max_prompt_len:
             best_k = mid
             low = mid + 1
         else:
@@ -137,16 +144,15 @@ def build_prompt_within_budget(
             "Sliding window dropped %d older turn(s) to fit %d tokens", dropped, max_prompt_len
         )
 
-    final = system + rest[-best_k:]
-    prompt = apply_template(final)
-    return prompt, count_tokens(prompt)
+    final = apply_template(system + rest[-best_k:])
+    return final, _count_or_release(final, count_tokens)
 
 
 # --- Stop sequences --------------------------------------------------------
 
 
 def normalize_stop(stop: str | list[str] | None) -> list[str]:
-    """Coerce the OpenAI ``stop`` field (string, list, or None) to a clean list."""
+    """Coerce the OpenAI ``stop`` field to a clean list."""
 
     if stop is None:
         return []

--- a/app/chat_format.py
+++ b/app/chat_format.py
@@ -1,11 +1,10 @@
 """Prompt construction for chat completions.
 
-Two responsibilities, both pure (they take tokenizer callables, no OpenVINO):
+Two responsibilities, both pure from the caller's perspective:
 
-1. Normalize OpenAI-style messages into plain ``{role, content}`` dicts that any
-   chat template can render (tool results / assistant tool-calls are flattened
-   to text, and tool messages are mapped to the user role for maximum template
-   compatibility).
+1. Normalize OpenAI-style messages into ``{role, content}`` dicts that an engine
+   can render. Text parts are flattened while validated image parts are retained
+   as private transport markers for a vision engine.
 2. Fit the conversation within a token budget using a whole-turn sliding window
    so the most recent context is preserved and older turns are dropped first.
 """
@@ -16,6 +15,7 @@ import json
 import logging
 from collections.abc import Callable
 
+from app import multimodal
 from app.openai_api import ChatMessage
 
 logger = logging.getLogger("ov-llm.chat")
@@ -25,30 +25,9 @@ CountTokens = Callable[[str], int]
 
 
 def _content_to_text(content: object) -> str:
-    """Convert OpenAI-style message content into text.
+    """Convert OpenAI content to text plus private multimodal transport markers."""
 
-    Chat Completions usually sends content as a string, but the Responses API and
-    some OpenAI-compatible clients send a list of content parts. Preserve textual
-    parts instead of rendering Python reprs such as ``[{'type': 'input_text', ...}]``.
-    """
-    if content is None:
-        return ""
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        parts: list[str] = []
-        for item in content:
-            if isinstance(item, str):
-                parts.append(item)
-            elif isinstance(item, dict):
-                for key in ("text", "content", "value"):
-                    value = item.get(key)
-                    if isinstance(value, str):
-                        parts.append(value)
-                        break
-        if parts:
-            return "\n".join(parts)
-    return str(content)
+    return multimodal.content_to_transport_text(content)
 
 
 def normalize_messages(
@@ -61,6 +40,7 @@ def normalize_messages(
     message instead of replacing it. This preserves caller-provided instructions
     while still injecting server-side tool-calling instructions.
     """
+
     out: list[dict] = []
     msgs = list(messages)
     has_leading_system = bool(msgs) and msgs[0].role == "system"
@@ -78,33 +58,32 @@ def normalize_messages(
         else:
             out.append({"role": "system", "content": system_override})
 
-    for m in msgs:
-        content = _content_to_text(m.content)
+    for message in msgs:
+        content = _content_to_text(message.content)
 
-        if m.role == "tool":
-            label = f" (call {m.tool_call_id})" if m.tool_call_id else ""
+        if message.role == "tool":
+            label = f" (call {message.tool_call_id})" if message.tool_call_id else ""
             out.append({"role": "user", "content": f"[tool result{label}]\n{content}"})
-
-        elif m.role == "assistant" and m.tool_calls:
+        elif message.role == "assistant" and message.tool_calls:
             calls = [
                 {
-                    "name": tc.get("function", {}).get("name", ""),
-                    "arguments": tc.get("function", {}).get("arguments", "{}"),
+                    "name": call.get("function", {}).get("name", ""),
+                    "arguments": call.get("function", {}).get("arguments", "{}"),
                 }
-                for tc in m.tool_calls
+                for call in message.tool_calls
             ]
             merged = (content + "\n" if content else "") + json.dumps(calls)
             out.append({"role": "assistant", "content": merged})
-
         else:
-            out.append({"role": m.role, "content": content})
+            out.append({"role": message.role, "content": content})
 
     return out
 
 
 def render_chatml(dict_messages: list[dict], add_generation_prompt: bool = True) -> str:
     """Fallback ChatML renderer for engines whose model has no chat template."""
-    parts = [f"<|im_start|>{m['role']}\n{m['content']}<|im_end|>\n" for m in dict_messages]
+
+    parts = [f"<|im_start|>{message['role']}\n{message['content']}<|im_end|>\n" for message in dict_messages]
     if add_generation_prompt:
         parts.append("<|im_start|>assistant\n")
     return "".join(parts)
@@ -120,11 +99,9 @@ def build_prompt_within_budget(
 
     The system message (if any) and the most recent turns are always kept; older
     whole turns are dropped from the front until the prompt fits. The single most
-    recent message is never dropped (if it alone exceeds the budget it is kept and
-    downstream ``max_new_tokens`` capping absorbs the overflow).
-
-    Returns ``(prompt, token_count)``.
+    recent message is never dropped.
     """
+
     if not dict_messages:
         prompt = apply_template([])
         return prompt, count_tokens(prompt)
@@ -134,18 +111,16 @@ def build_prompt_within_budget(
     if full_tokens <= max_prompt_len:
         return full, full_tokens
 
-    system = [m for m in dict_messages if m["role"] == "system"][:1]
-    rest = [m for m in dict_messages if m["role"] != "system"]
+    system = [message for message in dict_messages if message["role"] == "system"][:1]
+    rest = [message for message in dict_messages if message["role"] != "system"]
 
     if not rest:
-        # Only system messages and they exceed budget. Just return them.
         prompt = apply_template(system)
         return prompt, count_tokens(prompt)
 
-    # Binary search the number of messages to keep from the end of rest (1 to len(rest)).
     low = 1
     high = len(rest)
-    best_k = 1  # We must keep at least the single most recent message.
+    best_k = 1
 
     while low <= high:
         mid = (low + high) // 2
@@ -172,52 +147,45 @@ def build_prompt_within_budget(
 
 def normalize_stop(stop: str | list[str] | None) -> list[str]:
     """Coerce the OpenAI ``stop`` field (string, list, or None) to a clean list."""
+
     if stop is None:
         return []
     if isinstance(stop, str):
         return [stop] if stop else []
     result = []
-    for s in stop:
-        if isinstance(s, str) and s:
-            result.append(s)
-        elif s is not None:
-            logger.warning("Ignoring non-string stop entry: %r", s)
+    for item in stop:
+        if isinstance(item, str) and item:
+            result.append(item)
+        elif item is not None:
+            logger.warning("Ignoring non-string stop entry: %r", item)
     return result
 
 
 def truncate_at_stop(text: str, stop: list[str]) -> tuple[str, bool]:
-    """Cut ``text`` at the earliest occurrence of any stop sequence.
+    """Cut ``text`` at the earliest occurrence of any stop sequence."""
 
-    Returns ``(text, hit)`` where ``hit`` is True if a stop sequence was found
-    (and the stop sequence itself is excluded from the returned text).
-    """
     earliest = -1
-    for s in stop:
-        idx = text.find(s)
-        if idx != -1 and (earliest == -1 or idx < earliest):
-            earliest = idx
+    for item in stop:
+        index = text.find(item)
+        if index != -1 and (earliest == -1 or index < earliest):
+            earliest = index
     if earliest == -1:
         return text, False
     return text[:earliest], True
 
 
 class StopStreamer:
-    """Incrementally emit streamed text, stopping at the first stop sequence.
-
-    A stop sequence can straddle two streamed chunks, so the streamer withholds
-    the last ``max_stop_len - 1`` characters until more text confirms they are
-    not the start of a stop sequence. Call :meth:`feed` per chunk and
-    :meth:`flush` once the stream ends.
-    """
+    """Incrementally emit streamed text, stopping at the first stop sequence."""
 
     def __init__(self, stop: list[str]) -> None:
         self.stop = stop
-        self._maxlen = max((len(s) for s in stop), default=0)
+        self._maxlen = max((len(item) for item in stop), default=0)
         self._buffer = ""
         self.stopped = False
 
     def feed(self, piece: str) -> str:
         """Return the portion of ``piece`` that is safe to emit now."""
+
         if not self.stop:
             return piece
         if self.stopped:
@@ -228,7 +196,7 @@ class StopStreamer:
             self.stopped = True
             self._buffer = ""
             return text
-        keep = self._maxlen - 1  # possible partial stop-match to re-check next time
+        keep = self._maxlen - 1
         if keep <= 0:
             out, self._buffer = self._buffer, ""
             return out
@@ -240,6 +208,7 @@ class StopStreamer:
 
     def flush(self) -> str:
         """Emit any safely-held remainder once the stream has ended."""
+
         if self.stopped:
             return ""
         out, self._buffer = self._buffer, ""
@@ -250,7 +219,8 @@ def responses_input_to_messages(
     request_input: object,
     instructions: str | None = None,
 ) -> list[dict]:
-    """Convert a Responses-API ``input`` (string or message list) to message dicts."""
+    """Convert a Responses-API ``input`` into normalized message dictionaries."""
+
     out: list[dict] = []
     if instructions:
         out.append({"role": "system", "content": instructions})
@@ -258,12 +228,12 @@ def responses_input_to_messages(
     if isinstance(request_input, str):
         out.append({"role": "user", "content": request_input})
     elif isinstance(request_input, list):
-        for msg in request_input:
-            if isinstance(msg, dict):
+        for message in request_input:
+            if isinstance(message, dict):
                 out.append(
                     {
-                        "role": str(msg.get("role", "user")),
-                        "content": _content_to_text(msg.get("content", "")),
+                        "role": str(message.get("role", "user")),
+                        "content": _content_to_text(message.get("content", "")),
                     }
                 )
     else:

--- a/app/model_registry.py
+++ b/app/model_registry.py
@@ -1,10 +1,8 @@
-"""Model catalog: loading and validating ``models.json`` plus building the
-UI-facing status entries.
+"""Model catalog loading, validation, and UI-facing status entries.
 
-This module is intentionally free of any OpenVINO dependency. It only describes
-which models exist, where their OpenVINO IR directories live on disk, and how to
-present their current state to the web UI / API. Live runtime state (which
-engine is loaded on which device) is owned by :mod:`app.model_manager`.
+This module is intentionally free of OpenVINO runtime imports. It describes which
+models exist, where their OpenVINO IR directories live, and which API capabilities
+their configured backend provides.
 """
 
 from __future__ import annotations
@@ -14,11 +12,12 @@ import logging
 from dataclasses import dataclass
 from pathlib import Path
 
+from app import multimodal
+
 logger = logging.getLogger("ov-llm.registry")
 
-# Files that indicate a directory holds a converted OpenVINO IR model.
-# A generic config.json alone is not enough; Hugging Face source/cache
-# directories also contain config.json and would otherwise be misclassified.
+# Files that indicate a directory holds a converted OpenVINO IR model. A generic
+# config.json alone is not enough because Hugging Face caches contain one too.
 _IR_MARKERS = ("openvino_model.xml", "openvino_language_model.xml")
 
 _STATUS_LABELS = {
@@ -69,12 +68,22 @@ class ModelConfig:
     @property
     def max_prompt_len(self) -> int:
         """Token budget for the prompt, reserving room for the response."""
+
         return max(self.max_context_len - self.max_output_tokens, 64)
 
+    @property
+    def capabilities(self) -> tuple[str, ...]:
+        return multimodal.capabilities_for_backend(self.backend)
+
+    @property
+    def supports_vision(self) -> bool:
+        return multimodal.backend_supports_vision(self.backend)
+
     def abs_path(self, base_dir: Path) -> Path:
-        """Absolute path to the model's OpenVINO IR directory."""
-        p = Path(self.model_path)
-        return p if p.is_absolute() else (base_dir / p)
+        """Absolute path to this model's OpenVINO IR directory."""
+
+        path = Path(self.model_path)
+        return path if path.is_absolute() else (base_dir / path)
 
 
 def _coerce_entry(model_id: str, raw: dict) -> ModelConfig:
@@ -93,16 +102,16 @@ def _coerce_entry(model_id: str, raw: dict) -> ModelConfig:
 
 
 def load_catalog(models_file: Path) -> dict[str, ModelConfig]:
-    """Load and validate the model catalog. Returns ``{}`` on a missing/invalid file."""
+    """Load and validate the catalog. Return an empty mapping on invalid input."""
+
     path = Path(models_file)
     if not path.exists():
         logger.warning("Model catalog not found: %s", path)
         return {}
 
     try:
-        # utf-8-sig tolerates a UTF-8 BOM (a common Windows editor artifact).
-        with open(path, encoding="utf-8-sig") as f:
-            data = json.load(f)
+        with open(path, encoding="utf-8-sig") as file:
+            data = json.load(file)
     except (OSError, json.JSONDecodeError) as exc:
         logger.error("Failed to read model catalog %s: %s", path, exc)
         return {}
@@ -125,12 +134,12 @@ def load_catalog(models_file: Path) -> dict[str, ModelConfig]:
 
 def is_openvino_model_dir(model_dir: Path) -> bool:
     """Return whether *model_dir* contains a converted OpenVINO IR model."""
+
     model_dir = Path(model_dir)
     return model_dir.is_dir() and any((model_dir / marker).exists() for marker in _IR_MARKERS)
 
 
 def is_downloaded(cfg: ModelConfig, base_dir: Path) -> bool:
-    """True if a converted OpenVINO IR directory exists for this model."""
     return is_openvino_model_dir(cfg.abs_path(base_dir))
 
 
@@ -195,7 +204,8 @@ def make_catalog_entry(
     error: str | None = None,
     progress: dict | None = None,
 ) -> dict:
-    """Build a single UI/API-facing status entry for a model."""
+    """Build one UI/API-facing status entry."""
+
     if loaded:
         status = "loaded"
     elif error:
@@ -221,11 +231,9 @@ def make_catalog_entry(
         label = progress_payload["message"]
         if progress_payload.get("percent") is not None and is_busy_state:
             label = f"{label} ({progress_payload['percent']:.0f}%)"
-        # The existing frontend renders model.name prominently in both the main
-        # model card and the dropdown. Appending a short badge makes preparation
-        # progress visible without replacing the stable single-file UI.
         display_name = f"{cfg.name} — {badge}"
 
+    capabilities = list(cfg.capabilities)
     return {
         "id": cfg.id,
         "name": display_name,
@@ -242,6 +250,9 @@ def make_catalog_entry(
         "max_context_len": cfg.max_context_len,
         "max_output_tokens": cfg.max_output_tokens,
         "backend": cfg.backend,
+        "capabilities": capabilities,
+        "supports_vision": cfg.supports_vision,
+        "input_modalities": ["text", "image"] if cfg.supports_vision else ["text"],
         "can_load": (not loaded) and downloaded and not is_busy_state,
         "can_convert": (not loaded)
         and (not downloaded)
@@ -255,7 +266,8 @@ def make_catalog_entry(
 
 
 def save_catalog(models_file: Path, catalog: dict[str, ModelConfig]) -> None:
-    """Save the catalog dictionary to models.json (atomic write via tmp+rename)."""
+    """Save the catalog atomically."""
+
     data = {}
     for model_id, cfg in catalog.items():
         data[model_id] = {
@@ -271,6 +283,6 @@ def save_catalog(models_file: Path, catalog: dict[str, ModelConfig]) -> None:
         }
     models_file = Path(models_file)
     models_file.parent.mkdir(parents=True, exist_ok=True)
-    tmp = models_file.with_suffix(models_file.suffix + ".tmp")
-    tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
-    tmp.replace(models_file)
+    temp = models_file.with_suffix(models_file.suffix + ".tmp")
+    temp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    temp.replace(models_file)

--- a/app/multimodal.py
+++ b/app/multimodal.py
@@ -197,7 +197,9 @@ def content_to_transport_text(content: Any) -> str:
 
 
 def _purge_contexts_locked(now: float) -> None:
-    expired = [key for key, (created, _) in _contexts.items() if now - created > _CONTEXT_TTL_SECONDS]
+    expired = [
+        key for key, (created, _) in _contexts.items() if now - created > _CONTEXT_TTL_SECONDS
+    ]
     for key in expired:
         _contexts.pop(key, None)
     while len(_contexts) >= _CONTEXT_LIMIT:
@@ -298,7 +300,9 @@ def to_openvino_tensors(payloads: list[ImagePayload]) -> list[Any]:
         from openvino import Tensor
         from PIL import Image
     except ImportError as exc:  # pragma: no cover - real OpenVINO environments provide these
-        raise RuntimeError("OpenVINO, NumPy, and Pillow are required for vision inference.") from exc
+        raise RuntimeError(
+            "OpenVINO, NumPy, and Pillow are required for vision inference."
+        ) from exc
 
     tensors: list[Any] = []
     for payload in payloads:

--- a/app/multimodal.py
+++ b/app/multimodal.py
@@ -1,16 +1,8 @@
 """Validated image inputs and request-local transport for vision-language models.
 
-The OpenAI APIs represent images as content parts while the existing server passes a
-rendered prompt string into its engine abstraction.  This module bridges those two
-shapes without putting image bytes into the tokenizer prompt:
-
-* only local ``data:`` URLs are accepted (remote fetching is intentionally disabled)
-* image type, decoded size, dimensions, and per-request counts are bounded
-* normalized chat messages carry temporary image markers until an engine renders them
-* VLM engines exchange the markers for OpenVINO image tags and consume a short-lived
-  in-memory image context when generation starts
-
-Image payloads are never written to disk or added to browser conversation history.
+OpenAI APIs represent images as content parts while the server's established engine
+abstraction passes a rendered prompt string. This module bridges the two shapes without
+placing encoded image bytes in tokenizer prompts.
 """
 
 from __future__ import annotations
@@ -71,7 +63,6 @@ def _image_url_from_part(part: dict[str, Any]) -> str | None:
     part_type = str(part.get("type") or "").lower()
     if part_type not in {"image_url", "input_image"}:
         return None
-
     candidate: Any = part.get("image_url")
     if isinstance(candidate, dict):
         candidate = candidate.get("url")
@@ -81,10 +72,10 @@ def _image_url_from_part(part: dict[str, Any]) -> str | None:
 
 
 def decode_data_url(url: str) -> ImagePayload:
-    """Decode and verify one image data URL.
+    """Decode and verify one local image data URL.
 
-    Remote URLs are deliberately rejected.  This keeps the local server from becoming
-    an SSRF-capable fetch proxy and makes the privacy boundary explicit.
+    Remote URLs are deliberately rejected so the local API cannot become an SSRF-capable
+    fetch proxy and the privacy boundary remains explicit.
     """
 
     if not isinstance(url, str) or not url.startswith("data:"):
@@ -105,7 +96,6 @@ def decode_data_url(url: str) -> ImagePayload:
     if "base64" not in pieces[1:]:
         raise ValueError("Image data URLs must be base64 encoded.")
 
-    # Refuse obviously oversized payloads before allocating the decoded bytes.
     estimated_size = (len(encoded) * 3) // 4
     if estimated_size > MAX_IMAGE_BYTES + 3:
         raise ValueError(f"Each image must be {MAX_IMAGE_BYTES // (1024 * 1024)} MiB or smaller.")
@@ -120,7 +110,7 @@ def decode_data_url(url: str) -> ImagePayload:
 
     try:
         from PIL import Image, UnidentifiedImageError
-    except ImportError as exc:  # pragma: no cover - dependency is declared by the package
+    except ImportError as exc:  # pragma: no cover - declared dependency
         raise RuntimeError("Pillow is required for image validation.") from exc
 
     format_to_mime = {"JPEG": "image/jpeg", "PNG": "image/png", "WEBP": "image/webp"}
@@ -140,7 +130,6 @@ def decode_data_url(url: str) -> ImagePayload:
         raise ValueError("Image dimensions must be positive.")
     if width * height > MAX_IMAGE_PIXELS:
         raise ValueError(f"Image exceeds the {MAX_IMAGE_PIXELS:,}-pixel safety limit.")
-
     return ImagePayload(mime_type=mime_type, data=data, width=width, height=height)
 
 
@@ -225,7 +214,7 @@ def _store_context(payloads: list[ImagePayload]) -> str:
 
 
 def prepare_text_messages(messages: list[dict]) -> list[dict]:
-    """Remove private image bytes before a text-only tokenizer sees the messages."""
+    """Remove private image bytes before a text-only tokenizer sees messages."""
 
     prepared: list[dict] = []
     replacement = "[Image attached, but the selected model is not vision-capable.]"
@@ -242,7 +231,6 @@ def prepare_vision_messages(messages: list[dict]) -> tuple[list[dict], str | Non
 
     payloads: list[ImagePayload] = []
     prepared: list[dict] = []
-
     for message in messages:
         item = dict(message)
         content = str(item.get("content") or "")
@@ -275,6 +263,16 @@ def strip_prompt_context(prompt: str) -> str:
     return _CONTEXT_MARKER_RE.sub("", prompt)
 
 
+def discard_prompt_context(prompt: str) -> None:
+    """Release an image context for a prompt rendered only for token budgeting."""
+
+    match = _CONTEXT_MARKER_RE.search(prompt)
+    if not match:
+        return
+    with _context_lock:
+        _contexts.pop(match.group(1), None)
+
+
 def consume_prompt_context(prompt: str) -> tuple[str, list[ImagePayload]]:
     """Remove a prompt context marker and return its image payloads exactly once."""
 
@@ -305,7 +303,6 @@ def to_openvino_tensors(payloads: list[ImagePayload]) -> list[Any]:
     tensors: list[Any] = []
     for payload in payloads:
         with Image.open(io.BytesIO(payload.data)) as image:
-            # RGB conversion intentionally discards metadata such as EXIF before inference.
             rgb = image.convert("RGB")
             array = np.asarray(rgb, dtype=np.uint8)
         tensors.append(Tensor(array.reshape(1, array.shape[0], array.shape[1], 3)))

--- a/app/multimodal.py
+++ b/app/multimodal.py
@@ -1,0 +1,312 @@
+"""Validated image inputs and request-local transport for vision-language models.
+
+The OpenAI APIs represent images as content parts while the existing server passes a
+rendered prompt string into its engine abstraction.  This module bridges those two
+shapes without putting image bytes into the tokenizer prompt:
+
+* only local ``data:`` URLs are accepted (remote fetching is intentionally disabled)
+* image type, decoded size, dimensions, and per-request counts are bounded
+* normalized chat messages carry temporary image markers until an engine renders them
+* VLM engines exchange the markers for OpenVINO image tags and consume a short-lived
+  in-memory image context when generation starts
+
+Image payloads are never written to disk or added to browser conversation history.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import io
+import re
+import threading
+import time
+import uuid
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any
+
+SUPPORTED_IMAGE_MIME_TYPES = frozenset({"image/jpeg", "image/png", "image/webp"})
+MAX_IMAGE_BYTES = 10 * 1024 * 1024
+MAX_IMAGE_PIXELS = 25_000_000
+MAX_IMAGES_PER_REQUEST = 4
+MAX_REQUEST_IMAGE_BYTES = 24 * 1024 * 1024
+
+_IMAGE_MARKER_RE = re.compile(
+    r"<ovllm-image>(data:image/(?:jpeg|png|webp);base64,[A-Za-z0-9+/=]+)</ovllm-image>",
+    re.IGNORECASE,
+)
+_CONTEXT_MARKER_RE = re.compile(r"\s*<ovllm-image-context:([A-Za-z0-9_-]{8,64})>\s*$")
+_CONTEXT_TTL_SECONDS = 300
+_CONTEXT_LIMIT = 64
+
+
+@dataclass(frozen=True)
+class ImagePayload:
+    mime_type: str
+    data: bytes
+    width: int
+    height: int
+
+
+_context_lock = threading.Lock()
+_contexts: OrderedDict[str, tuple[float, list[ImagePayload]]] = OrderedDict()
+
+
+def backend_supports_vision(backend: str | None) -> bool:
+    value = str(backend or "").lower()
+    return "vlm" in value or "vision" in value
+
+
+def capabilities_for_backend(backend: str | None) -> tuple[str, ...]:
+    value = str(backend or "").lower()
+    if "embedding" in value:
+        return ("embeddings",)
+    if backend_supports_vision(value):
+        return ("chat", "vision")
+    return ("chat",)
+
+
+def _image_url_from_part(part: dict[str, Any]) -> str | None:
+    part_type = str(part.get("type") or "").lower()
+    if part_type not in {"image_url", "input_image"}:
+        return None
+
+    candidate: Any = part.get("image_url")
+    if isinstance(candidate, dict):
+        candidate = candidate.get("url")
+    if not candidate and part_type == "input_image":
+        candidate = part.get("file_data") or part.get("data")
+    return candidate if isinstance(candidate, str) else None
+
+
+def decode_data_url(url: str) -> ImagePayload:
+    """Decode and verify one image data URL.
+
+    Remote URLs are deliberately rejected.  This keeps the local server from becoming
+    an SSRF-capable fetch proxy and makes the privacy boundary explicit.
+    """
+
+    if not isinstance(url, str) or not url.startswith("data:"):
+        raise ValueError(
+            "Image inputs must use a base64 data URL; remote image URLs are not fetched."
+        )
+    try:
+        header, encoded = url.split(",", 1)
+    except ValueError as exc:
+        raise ValueError("Image data URL is malformed.") from exc
+
+    metadata = header[5:].lower()
+    pieces = [item.strip() for item in metadata.split(";") if item.strip()]
+    mime_type = pieces[0] if pieces else ""
+    if mime_type not in SUPPORTED_IMAGE_MIME_TYPES:
+        supported = ", ".join(sorted(SUPPORTED_IMAGE_MIME_TYPES))
+        raise ValueError(f"Unsupported image type '{mime_type or 'unknown'}'. Use {supported}.")
+    if "base64" not in pieces[1:]:
+        raise ValueError("Image data URLs must be base64 encoded.")
+
+    # Refuse obviously oversized payloads before allocating the decoded bytes.
+    estimated_size = (len(encoded) * 3) // 4
+    if estimated_size > MAX_IMAGE_BYTES + 3:
+        raise ValueError(f"Each image must be {MAX_IMAGE_BYTES // (1024 * 1024)} MiB or smaller.")
+    try:
+        data = base64.b64decode(encoded, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("Image data URL contains invalid base64 data.") from exc
+    if not data:
+        raise ValueError("Image input is empty.")
+    if len(data) > MAX_IMAGE_BYTES:
+        raise ValueError(f"Each image must be {MAX_IMAGE_BYTES // (1024 * 1024)} MiB or smaller.")
+
+    try:
+        from PIL import Image, UnidentifiedImageError
+    except ImportError as exc:  # pragma: no cover - dependency is declared by the package
+        raise RuntimeError("Pillow is required for image validation.") from exc
+
+    format_to_mime = {"JPEG": "image/jpeg", "PNG": "image/png", "WEBP": "image/webp"}
+    try:
+        with Image.open(io.BytesIO(data)) as image:
+            width, height = image.size
+            actual_mime = format_to_mime.get(str(image.format or "").upper())
+            image.verify()
+    except (UnidentifiedImageError, OSError, ValueError) as exc:
+        raise ValueError("Image data could not be decoded as JPEG, PNG, or WebP.") from exc
+
+    if actual_mime != mime_type:
+        raise ValueError(
+            f"Image content is {actual_mime or 'an unknown format'}, not the declared {mime_type}."
+        )
+    if width <= 0 or height <= 0:
+        raise ValueError("Image dimensions must be positive.")
+    if width * height > MAX_IMAGE_PIXELS:
+        raise ValueError(f"Image exceeds the {MAX_IMAGE_PIXELS:,}-pixel safety limit.")
+
+    return ImagePayload(mime_type=mime_type, data=data, width=width, height=height)
+
+
+def validate_content(content: Any) -> Any:
+    """Pydantic field validator for OpenAI-style message content."""
+
+    if not isinstance(content, list):
+        return content
+    payloads: list[ImagePayload] = []
+    for part in content:
+        if not isinstance(part, dict):
+            continue
+        url = _image_url_from_part(part)
+        if url is not None:
+            payloads.append(decode_data_url(url))
+    if len(payloads) > MAX_IMAGES_PER_REQUEST:
+        raise ValueError(f"A request may contain at most {MAX_IMAGES_PER_REQUEST} images.")
+    if sum(len(payload.data) for payload in payloads) > MAX_REQUEST_IMAGE_BYTES:
+        raise ValueError(
+            f"Combined image data must be {MAX_REQUEST_IMAGE_BYTES // (1024 * 1024)} MiB or smaller."
+        )
+    return content
+
+
+def content_to_transport_text(content: Any) -> str:
+    """Flatten text parts and retain validated images as private transport markers."""
+
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return str(content)
+
+    parts: list[str] = []
+    image_count = 0
+    image_bytes = 0
+    for item in content:
+        if isinstance(item, str):
+            parts.append(item)
+            continue
+        if not isinstance(item, dict):
+            continue
+
+        url = _image_url_from_part(item)
+        if url is not None:
+            payload = decode_data_url(url)
+            image_count += 1
+            image_bytes += len(payload.data)
+            if image_count > MAX_IMAGES_PER_REQUEST:
+                raise ValueError(f"A request may contain at most {MAX_IMAGES_PER_REQUEST} images.")
+            if image_bytes > MAX_REQUEST_IMAGE_BYTES:
+                raise ValueError(
+                    f"Combined image data must be {MAX_REQUEST_IMAGE_BYTES // (1024 * 1024)} MiB or smaller."
+                )
+            parts.append(f"<ovllm-image>{url}</ovllm-image>")
+            continue
+
+        for key in ("text", "content", "value"):
+            value = item.get(key)
+            if isinstance(value, str):
+                parts.append(value)
+                break
+    return "\n".join(parts)
+
+
+def _purge_contexts_locked(now: float) -> None:
+    expired = [key for key, (created, _) in _contexts.items() if now - created > _CONTEXT_TTL_SECONDS]
+    for key in expired:
+        _contexts.pop(key, None)
+    while len(_contexts) >= _CONTEXT_LIMIT:
+        _contexts.popitem(last=False)
+
+
+def _store_context(payloads: list[ImagePayload]) -> str:
+    key = uuid.uuid4().hex
+    now = time.monotonic()
+    with _context_lock:
+        _purge_contexts_locked(now)
+        _contexts[key] = (now, payloads)
+    return key
+
+
+def prepare_text_messages(messages: list[dict]) -> list[dict]:
+    """Remove private image bytes before a text-only tokenizer sees the messages."""
+
+    prepared: list[dict] = []
+    replacement = "[Image attached, but the selected model is not vision-capable.]"
+    for message in messages:
+        item = dict(message)
+        content = str(item.get("content") or "")
+        item["content"] = _IMAGE_MARKER_RE.sub(replacement, content)
+        prepared.append(item)
+    return prepared
+
+
+def prepare_vision_messages(messages: list[dict]) -> tuple[list[dict], str | None]:
+    """Replace private image markers with generic OpenVINO image tags."""
+
+    payloads: list[ImagePayload] = []
+    prepared: list[dict] = []
+
+    for message in messages:
+        item = dict(message)
+        content = str(item.get("content") or "")
+
+        def replace(match: re.Match[str]) -> str:
+            if len(payloads) >= MAX_IMAGES_PER_REQUEST:
+                raise ValueError(f"A request may contain at most {MAX_IMAGES_PER_REQUEST} images.")
+            payloads.append(decode_data_url(match.group(1)))
+            return f"<ov_genai_image_{len(payloads) - 1}>"
+
+        item["content"] = _IMAGE_MARKER_RE.sub(replace, content)
+        prepared.append(item)
+
+    if not payloads:
+        return prepared, None
+    if sum(len(payload.data) for payload in payloads) > MAX_REQUEST_IMAGE_BYTES:
+        raise ValueError(
+            f"Combined image data must be {MAX_REQUEST_IMAGE_BYTES // (1024 * 1024)} MiB or smaller."
+        )
+    return prepared, _store_context(payloads)
+
+
+def append_prompt_context(prompt: str, context_key: str | None) -> str:
+    if not context_key:
+        return prompt
+    return f"{prompt}\n<ovllm-image-context:{context_key}>"
+
+
+def strip_prompt_context(prompt: str) -> str:
+    return _CONTEXT_MARKER_RE.sub("", prompt)
+
+
+def consume_prompt_context(prompt: str) -> tuple[str, list[ImagePayload]]:
+    """Remove a prompt context marker and return its image payloads exactly once."""
+
+    match = _CONTEXT_MARKER_RE.search(prompt)
+    if not match:
+        return prompt, []
+    clean_prompt = prompt[: match.start()].rstrip()
+    key = match.group(1)
+    with _context_lock:
+        item = _contexts.pop(key, None)
+    if item is None:
+        raise RuntimeError("Image context expired before generation started. Retry the request.")
+    return clean_prompt, item[1]
+
+
+def to_openvino_tensors(payloads: list[ImagePayload]) -> list[Any]:
+    """Convert validated encoded images to OpenVINO uint8 NHWC tensors."""
+
+    if not payloads:
+        return []
+    try:
+        import numpy as np
+        from openvino import Tensor
+        from PIL import Image
+    except ImportError as exc:  # pragma: no cover - real OpenVINO environments provide these
+        raise RuntimeError("OpenVINO, NumPy, and Pillow are required for vision inference.") from exc
+
+    tensors: list[Any] = []
+    for payload in payloads:
+        with Image.open(io.BytesIO(payload.data)) as image:
+            # RGB conversion intentionally discards metadata such as EXIF before inference.
+            rgb = image.convert("RGB")
+            array = np.asarray(rgb, dtype=np.uint8)
+        tensors.append(Tensor(array.reshape(1, array.shape[0], array.shape[1], 3)))
+    return tensors

--- a/app/openai_api.py
+++ b/app/openai_api.py
@@ -1,8 +1,9 @@
 """OpenAI-compatible request/response models (Pydantic v2).
 
 These mirror the subset of the OpenAI API the server implements: chat
-completions (with streaming + tool calling) and the Responses API used by tools
-like n8n. They are plain data models with no OpenVINO dependency.
+completions (with streaming + tool calling), multimodal image inputs, and the
+Responses API used by tools like n8n. They are plain data models with no
+OpenVINO dependency.
 """
 
 from __future__ import annotations
@@ -11,6 +12,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
+from app import multimodal
 from runtime import device_check
 
 # --- Chat messages ---------------------------------------------------------
@@ -21,6 +23,11 @@ class ChatMessage(BaseModel):
     content: Any = None  # str, list of content parts, or None (OpenAI spec allows all three)
     tool_calls: list[dict[str, Any]] | None = None
     tool_call_id: str | None = None
+
+    @field_validator("content")
+    @classmethod
+    def validate_multimodal_content(cls, value: Any) -> Any:
+        return multimodal.validate_content(value)
 
 
 # --- Tool / function calling ----------------------------------------------
@@ -112,6 +119,15 @@ class ResponseRequest(BaseModel):
     lora_path: str | None = None
     lora_alpha: float | None = Field(default=1.0, gt=0.0)
 
+    @field_validator("input")
+    @classmethod
+    def validate_multimodal_input(cls, value: Any) -> Any:
+        if isinstance(value, list):
+            for message in value:
+                if isinstance(message, dict):
+                    multimodal.validate_content(message.get("content"))
+        return value
+
 
 class ResponseOutputMessage(BaseModel):
     type: str = "message"
@@ -168,6 +184,10 @@ class ModelRegisterRequest(BaseModel):
     )
     name: str = Field(min_length=1, max_length=160)
     source_model: str = Field(min_length=1, max_length=240)
+    backend: str = Field(
+        default="openvino-genai",
+        pattern=r"^(openvino-genai|openvino-embeddings|openvino-vlm)$",
+    )
     weight_format: str = Field(default="int4", pattern=r"^(int4|int8|fp16)$")
     recommended_device: str = Field(default="NPU", min_length=1, max_length=64)
     max_context_len: int = Field(default=2048, ge=128, le=262144)
@@ -242,7 +262,8 @@ class DownloadCustomRequest(BaseModel):
     name: str = Field(min_length=1, max_length=160)
     source_model: str = Field(min_length=1, max_length=240)
     backend: str = Field(
-        default="openvino-genai", pattern=r"^(openvino-genai|openvino-embeddings)$"
+        default="openvino-genai",
+        pattern=r"^(openvino-genai|openvino-embeddings|openvino-vlm)$",
     )
     weight_format: str = Field(default="int4", pattern=r"^(int4|int8|fp16)$")
     group_size: int | None = Field(default=None, ge=-1)

--- a/app/ui_extension.py
+++ b/app/ui_extension.py
@@ -1,0 +1,369 @@
+"""Inject the multimodal UI extension into the existing single-file browser client.
+
+Keeping the extension here avoids a risky rewrite of the large, intentionally standalone
+``web/index.html`` file.  The patch is limited to that one response and leaves every
+other ``FileResponse`` untouched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.responses import FileResponse, HTMLResponse
+
+_EXTENSION_ID = "ovllm-vision-extension"
+_ORIGINAL_FILE_RESPONSE_CALL = FileResponse.__call__
+_INSTALLED = False
+
+VISION_EXTENSION_JS = r"""
+(() => {
+    'use strict';
+    if (window.__ovllmVisionInstalled) return;
+    window.__ovllmVisionInstalled = true;
+
+    const MAX_IMAGES = 4;
+    const MAX_BYTES = 10 * 1024 * 1024;
+    const MAX_PIXELS = 25000000;
+    const SUPPORTED = new Set(['image/jpeg', 'image/png', 'image/webp']);
+    const modelCapabilities = new Map();
+    let pendingImages = [];
+
+    const form = document.getElementById('chat-form');
+    const inputArea = document.getElementById('input-area');
+    const userInput = document.getElementById('user-input');
+    const modelSelect = document.getElementById('model-select');
+    if (!form || !inputArea || !userInput || !modelSelect) return;
+
+    const style = document.createElement('style');
+    style.textContent = `
+        #vision-attach-btn {
+            width: 42px; height: 42px; flex: 0 0 42px; border-radius: 11px;
+            border: 1px solid var(--border); background: var(--surface-2);
+            color: var(--text-2); cursor: pointer; display: grid; place-items: center;
+            transition: border-color .2s, color .2s, background .2s, opacity .2s;
+        }
+        #vision-attach-btn:hover:not(:disabled) { border-color: var(--primary); color: var(--text-1); background: var(--surface-3); }
+        #vision-attach-btn:disabled { opacity: .42; cursor: not-allowed; }
+        #vision-attach-btn.has-images { color: var(--primary); border-color: var(--primary); box-shadow: 0 0 0 3px var(--primary-glow); }
+        #vision-preview-tray { display: none; gap: 8px; align-items: center; overflow-x: auto; padding: 0 2px 8px; }
+        #vision-preview-tray.visible { display: flex; }
+        .vision-preview { position: relative; flex: 0 0 auto; width: 58px; height: 58px; border: 1px solid var(--border); border-radius: 10px; overflow: hidden; background: var(--surface-2); }
+        .vision-preview img { width: 100%; height: 100%; object-fit: cover; display: block; }
+        .vision-preview button { position: absolute; top: 3px; right: 3px; width: 20px; height: 20px; border: 0; border-radius: 50%; background: rgba(5,8,15,.82); color: white; cursor: pointer; font-size: 14px; line-height: 20px; }
+        .vision-preview-count { flex: 0 0 auto; font-size: 11px; color: var(--text-3); line-height: 1.35; max-width: 190px; }
+        #input-area.vision-drag-active { outline: 2px dashed var(--primary); outline-offset: -7px; border-radius: 16px; }
+        @media (max-width: 640px) { #vision-attach-btn { width: 40px; height: 40px; flex-basis: 40px; } }
+    `;
+    document.head.appendChild(style);
+
+    const fileInput = document.createElement('input');
+    fileInput.type = 'file';
+    fileInput.accept = 'image/jpeg,image/png,image/webp';
+    fileInput.multiple = true;
+    fileInput.hidden = true;
+    fileInput.id = 'vision-file-input';
+
+    const attachButton = document.createElement('button');
+    attachButton.type = 'button';
+    attachButton.id = 'vision-attach-btn';
+    attachButton.setAttribute('aria-label', 'Attach images');
+    attachButton.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="m21 15-5-5L5 21"/></svg>';
+
+    const previewTray = document.createElement('div');
+    previewTray.id = 'vision-preview-tray';
+    previewTray.setAttribute('aria-live', 'polite');
+
+    form.insertBefore(attachButton, userInput);
+    form.appendChild(fileInput);
+    inputArea.insertBefore(previewTray, form);
+
+    const customBackend = document.getElementById('custom-backend');
+    if (customBackend && !customBackend.querySelector('option[value="openvino-vlm"]')) {
+        const option = document.createElement('option');
+        option.value = 'openvino-vlm';
+        option.textContent = 'Vision + Text (openvino-vlm)';
+        customBackend.appendChild(option);
+    }
+    const hfTask = document.getElementById('hf-search-task');
+    if (hfTask && !hfTask.querySelector('option[value="image-text-to-text"]')) {
+        const option = document.createElement('option');
+        option.value = 'image-text-to-text';
+        option.textContent = 'Vision Language Models (VLMs)';
+        hfTask.appendChild(option);
+    }
+
+    function toast(message) {
+        const element = document.getElementById('toast');
+        if (!element) return;
+        element.textContent = message;
+        element.classList.add('show');
+        window.setTimeout(() => element.classList.remove('show'), 2600);
+    }
+
+    function selectedSupportsVision() {
+        return modelCapabilities.get(modelSelect.value)?.supports_vision === true;
+    }
+
+    function updateAttachState() {
+        const known = modelCapabilities.has(modelSelect.value);
+        const capable = selectedSupportsVision();
+        attachButton.disabled = !known || !capable;
+        attachButton.classList.toggle('has-images', pendingImages.length > 0);
+        attachButton.title = !known
+            ? 'Checking whether this model supports images…'
+            : capable
+                ? 'Attach up to four JPEG, PNG, or WebP images'
+                : 'Select a vision-capable model to attach images';
+        if (known && !capable && pendingImages.length) {
+            pendingImages = [];
+            renderPreviews();
+            toast('Image attachments cleared because the selected model is text-only.');
+        }
+    }
+
+    function renderPreviews() {
+        previewTray.replaceChildren();
+        previewTray.classList.toggle('visible', pendingImages.length > 0);
+        pendingImages.forEach((item, index) => {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'vision-preview';
+            wrapper.title = `${item.name} · ${item.width}×${item.height}`;
+            const image = document.createElement('img');
+            image.src = item.dataUrl;
+            image.alt = '';
+            const remove = document.createElement('button');
+            remove.type = 'button';
+            remove.setAttribute('aria-label', `Remove ${item.name}`);
+            remove.textContent = '×';
+            remove.addEventListener('click', () => {
+                pendingImages.splice(index, 1);
+                renderPreviews();
+            });
+            wrapper.append(image, remove);
+            previewTray.appendChild(wrapper);
+        });
+        if (pendingImages.length) {
+            const note = document.createElement('div');
+            note.className = 'vision-preview-count';
+            note.textContent = `${pendingImages.length}/${MAX_IMAGES} attached · sent with the next request only`;
+            previewTray.appendChild(note);
+        }
+        attachButton.classList.toggle('has-images', pendingImages.length > 0);
+    }
+
+    function readAsDataUrl(file) {
+        return new Promise((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onerror = () => reject(new Error(`Could not read ${file.name}`));
+            reader.onload = () => resolve(String(reader.result || ''));
+            reader.readAsDataURL(file);
+        });
+    }
+
+    function imageDimensions(dataUrl) {
+        return new Promise((resolve, reject) => {
+            const image = new Image();
+            image.onload = () => resolve({ width: image.naturalWidth, height: image.naturalHeight });
+            image.onerror = () => reject(new Error('Image could not be decoded'));
+            image.src = dataUrl;
+        });
+    }
+
+    async function addFiles(fileList) {
+        if (!selectedSupportsVision()) {
+            toast('Select a loaded vision-capable model before attaching an image.');
+            return;
+        }
+        for (const file of Array.from(fileList || [])) {
+            if (pendingImages.length >= MAX_IMAGES) {
+                toast(`A maximum of ${MAX_IMAGES} images can be attached.`);
+                break;
+            }
+            if (!SUPPORTED.has(file.type)) {
+                toast(`${file.name}: use JPEG, PNG, or WebP.`);
+                continue;
+            }
+            if (file.size > MAX_BYTES) {
+                toast(`${file.name}: images must be 10 MiB or smaller.`);
+                continue;
+            }
+            try {
+                const dataUrl = await readAsDataUrl(file);
+                const dimensions = await imageDimensions(dataUrl);
+                if (!dimensions.width || !dimensions.height || dimensions.width * dimensions.height > MAX_PIXELS) {
+                    throw new Error('image exceeds the 25,000,000-pixel safety limit');
+                }
+                pendingImages.push({
+                    name: file.name || `image-${pendingImages.length + 1}`,
+                    type: file.type,
+                    size: file.size,
+                    dataUrl,
+                    width: dimensions.width,
+                    height: dimensions.height,
+                });
+            } catch (error) {
+                toast(`${file.name}: ${error.message}`);
+            }
+        }
+        fileInput.value = '';
+        renderPreviews();
+    }
+
+    attachButton.addEventListener('click', () => {
+        if (selectedSupportsVision()) fileInput.click();
+        else toast('Select a vision-capable model first.');
+    });
+    fileInput.addEventListener('change', () => addFiles(fileInput.files));
+
+    inputArea.addEventListener('dragover', event => {
+        if (!event.dataTransfer?.types?.includes('Files')) return;
+        event.preventDefault();
+        if (selectedSupportsVision()) inputArea.classList.add('vision-drag-active');
+    });
+    inputArea.addEventListener('dragleave', () => inputArea.classList.remove('vision-drag-active'));
+    inputArea.addEventListener('drop', event => {
+        if (!event.dataTransfer?.files?.length) return;
+        event.preventDefault();
+        inputArea.classList.remove('vision-drag-active');
+        addFiles(event.dataTransfer.files);
+    });
+    userInput.addEventListener('paste', event => {
+        const files = Array.from(event.clipboardData?.files || []).filter(file => file.type.startsWith('image/'));
+        if (files.length) addFiles(files);
+    });
+
+    modelSelect.addEventListener('change', updateAttachState);
+    ['new-chat-btn', 'new-chat-side-btn'].forEach(id => {
+        document.getElementById(id)?.addEventListener('click', () => {
+            pendingImages = [];
+            renderPreviews();
+        });
+    });
+
+    function recordCapabilities(data) {
+        const models = data?.models?.available;
+        if (!Array.isArray(models)) return;
+        modelCapabilities.clear();
+        models.forEach(model => modelCapabilities.set(model.id, model));
+        updateAttachState();
+    }
+
+    function responseWithJson(data, source) {
+        const headers = new Headers(source.headers);
+        headers.delete('content-length');
+        headers.delete('content-encoding');
+        headers.set('content-type', 'application/json');
+        return new Response(JSON.stringify(data), {
+            status: source.status,
+            statusText: source.statusText,
+            headers,
+        });
+    }
+
+    const originalFetch = window.fetch.bind(window);
+    window.fetch = async function visionAwareFetch(input, init = {}) {
+        const url = typeof input === 'string' ? input : input?.url || '';
+        const method = String(init?.method || (typeof input !== 'string' && input?.method) || 'GET').toUpperCase();
+
+        if (url.includes('/v1/chat/completions') && method === 'POST' && pendingImages.length) {
+            let body;
+            try { body = JSON.parse(String(init.body || '')); }
+            catch { return originalFetch(input, init); }
+
+            const capabilities = modelCapabilities.get(body.model);
+            if (!capabilities?.supports_vision) {
+                toast('The selected model cannot process images. Choose a vision-capable model.');
+                return responseWithJson({ detail: 'Selected model is not vision-capable.' }, new Response('', { status: 400 }));
+            }
+
+            const messages = Array.isArray(body.messages) ? body.messages : [];
+            let userMessage = null;
+            for (let index = messages.length - 1; index >= 0; index -= 1) {
+                if (messages[index]?.role === 'user') { userMessage = messages[index]; break; }
+            }
+            if (userMessage) {
+                const content = Array.isArray(userMessage.content)
+                    ? [...userMessage.content]
+                    : [{ type: 'text', text: String(userMessage.content || '') }];
+                pendingImages.forEach(item => content.push({
+                    type: 'image_url',
+                    image_url: { url: item.dataUrl, detail: 'auto' },
+                }));
+                userMessage.content = content;
+                body.messages = messages;
+                init = { ...init, body: JSON.stringify(body) };
+                pendingImages = [];
+                renderPreviews();
+            }
+        }
+
+        const response = await originalFetch(input, init);
+
+        if (url.includes('/v1/system/status') && response.ok) {
+            response.clone().json().then(recordCapabilities).catch(() => {});
+        }
+
+        if (url.includes('/v1/models/search-hf') && url.includes('task=image-text-to-text') && response.ok) {
+            try {
+                const data = await response.clone().json();
+                if (Array.isArray(data)) data.forEach(item => { item.backend = 'openvino-vlm'; });
+                return responseWithJson(data, response);
+            } catch { /* preserve the original response */ }
+        }
+        return response;
+    };
+
+    async function refreshCapabilities() {
+        const key = localStorage.getItem('ovllm.apikey.v1') || '';
+        const headers = key ? { Authorization: `Bearer ${key}` } : {};
+        try {
+            const response = await originalFetch('/v1/system/status', { headers });
+            if (response.ok) recordCapabilities(await response.json());
+        } catch { /* the existing application will continue polling */ }
+    }
+
+    updateAttachState();
+    refreshCapabilities();
+})();
+"""
+
+
+def inject_multimodal_ui(html: str) -> str:
+    """Return *html* with the extension inserted once before ``</body>``."""
+
+    if f'id="{_EXTENSION_ID}"' in html:
+        return html
+    script = f'\n<script id="{_EXTENSION_ID}">\n{VISION_EXTENSION_JS}\n</script>\n'
+    if "</body>" in html:
+        return html.replace("</body>", f"{script}</body>", 1)
+    return html + script
+
+
+def install_ui_extension() -> None:
+    """Patch ``FileResponse`` narrowly for the bundled ``web/index.html`` page."""
+
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    _INSTALLED = True
+
+    async def patched_call(self: FileResponse, scope, receive, send) -> None:
+        path = Path(self.path)
+        if path.name == "index.html" and path.parent.name == "web" and path.is_file():
+            html = inject_multimodal_ui(path.read_text(encoding="utf-8"))
+            headers = {
+                key: value
+                for key, value in self.headers.items()
+                if key.lower() not in {"content-length", "content-type", "etag", "last-modified"}
+            }
+            response = HTMLResponse(
+                html,
+                status_code=self.status_code,
+                headers=headers,
+                background=self.background,
+            )
+            await response(scope, receive, send)
+            return
+        await _ORIGINAL_FILE_RESPONSE_CALL(self, scope, receive, send)
+
+    FileResponse.__call__ = patched_call

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,0 +1,137 @@
+# Local vision chat
+
+OpenVINO Windows LLM can serve vision-language models through the same local,
+OpenAI-compatible API used for text chat. Image bytes remain local and are held in
+memory only for the active request.
+
+## Supported input
+
+- JPEG, PNG, and WebP
+- up to 4 images per request
+- up to 10 MiB per image
+- up to 24 MiB combined image data
+- up to 25,000,000 decoded pixels per image
+- base64 `data:` URLs only
+
+Remote `http://` and `https://` image URLs are intentionally rejected. The server does
+not fetch user-controlled URLs, which avoids turning a LAN-bound installation into an
+SSRF-capable proxy.
+
+## Browser interface
+
+Select a model registered with the `openvino-vlm` backend. The composer then enables an
+image button and supports:
+
+- file selection
+- drag and drop
+- pasting a screenshot from the clipboard
+- attachment previews and removal
+
+Attachments are sent with the next request only. The browser conversation store keeps
+the text message but does not retain base64 image data.
+
+## Register and convert a VLM
+
+Use **Add custom model** in the browser and select **Vision + Text
+(openvino-vlm)**, or call the API:
+
+```powershell
+$body = @{
+  model_id = "local-vision-int4"
+  name = "Local Vision INT4"
+  source_model = "<trusted Hugging Face VLM repository>"
+  backend = "openvino-vlm"
+  weight_format = "int4"
+  recommended_device = "GPU"
+  max_context_len = 4096
+  max_output_tokens = 512
+  load_after = $true
+} | ConvertTo-Json
+
+Invoke-RestMethod `
+  -Method Post `
+  -Uri http://127.0.0.1:8000/v1/models/download-custom `
+  -ContentType application/json `
+  -Body $body
+```
+
+The converter selects Optimum's `image-text-to-text` task for `openvino-vlm`
+registrations. Model architecture, OpenVINO GenAI version, driver, precision, and target
+device must still be compatible. Start with CPU or GPU unless the chosen VLM explicitly
+supports your NPU path.
+
+## Chat Completions API
+
+```python
+import base64
+from pathlib import Path
+
+import httpx
+
+image = base64.b64encode(Path("screenshot.png").read_bytes()).decode("ascii")
+payload = {
+    "model": "local-vision-int4",
+    "messages": [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe this screenshot and identify the error."},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/png;base64,{image}"},
+                },
+            ],
+        }
+    ],
+    "stream": False,
+}
+
+response = httpx.post(
+    "http://127.0.0.1:8000/v1/chat/completions",
+    json=payload,
+    timeout=120,
+)
+response.raise_for_status()
+print(response.json()["choices"][0]["message"]["content"])
+```
+
+Streaming uses the same request shape with `"stream": true`.
+
+## Responses API
+
+```json
+{
+  "model": "local-vision-int4",
+  "input": [
+    {
+      "role": "user",
+      "content": [
+        {"type": "input_text", "text": "What is shown in this image?"},
+        {
+          "type": "input_image",
+          "image_url": "data:image/png;base64,<BASE64_DATA>"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Runtime behavior
+
+The request parser validates encoded size, decoded format, and image dimensions before
+inference. A VLM engine replaces private transport markers with OpenVINO GenAI image
+tags and supplies decoded `ov.Tensor` images to `VLMPipeline`. Temporary image contexts
+are consumed once and released when prompt-budget candidates are discarded.
+
+Text-only models never receive base64 image bytes. The browser disables attachments for
+those models, and API-side prompt normalization replaces unexpected image parts with an
+explicit text-only warning.
+
+## Validation status
+
+Mock mode exercises image validation, OpenAI content-part parsing, browser request
+construction, prompt budgeting, lifecycle routing, streaming, and cancellation without
+claiming real hardware support. Publish a real Windows CPU, GPU, or NPU compatibility
+result only after the repository's hardware certification workflow succeeds with the
+specific VLM and device.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "openvino-windows-llm"
-version = "0.1.0"
-description = "Windows-first local LLM server built on OpenVINO GenAI for Intel CPU/GPU/NPU."
+version = "0.2.0"
+description = "Windows-first local LLM and VLM server built on OpenVINO GenAI for Intel CPU/GPU/NPU."
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT" }
@@ -12,6 +12,7 @@ dependencies = [
     "pydantic>=2.6.0",
     "python-dotenv>=1.0.0",
     "psutil>=5.9.0",
+    "pillow>=10.0.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Runtime dependencies for the OpenVINO Windows LLM server.
+# Runtime dependencies for the OpenVINO Windows LLM and VLM server.
 #   pip install -r requirements.txt
 #
 # Unlike the legacy IPEX repo, normal runtime inference does NOT require pinning
@@ -16,6 +16,8 @@ pydantic>=2.6.0
 # --- Utilities ---
 python-dotenv>=1.0.0
 psutil>=5.9.0
+# Validates and decodes local JPEG, PNG, and WebP image inputs for VLM requests.
+pillow>=10.0.0
 
 # --- Windows enterprise TLS trust (no-op / not installed elsewhere) ---
 # Merges the Windows OS trust store into certifi so Hugging Face conversions

--- a/runtime/model_converter.py
+++ b/runtime/model_converter.py
@@ -1,14 +1,8 @@
-"""Helper for exporting Hugging Face models to OpenVINO IR via Optimum Intel.
+"""Export Hugging Face models to OpenVINO IR via Optimum Intel.
 
 Conversion is a separate, heavier step than serving and requires the extra
-``requirements-convert.txt`` dependencies. This module builds and runs the
-``optimum-cli export openvino`` command and can resolve a model by its
-``models.json`` id so paths/weights stay consistent with the server.
-
-Usage:
-    python -m runtime.model_converter --id tinyllama-1.1b-chat-fp16
-    python -m runtime.model_converter --model Qwen/Qwen2.5-1.5B-Instruct \
-        --output models/openvino/qwen2.5-1.5b-instruct-fp16 --weight-format fp16
+``requirements-convert.txt`` dependencies. Catalog backends select the matching
+Optimum task for text generation, embeddings, or vision-language models.
 """
 
 from __future__ import annotations
@@ -21,8 +15,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-# Ensure the virtual environment's Scripts/bin directory is on PATH so that
-# optimum-cli can be found when running within the venv.
 _venv_bin = str(Path(sys.executable).parent)
 if _venv_bin not in os.environ.get("PATH", ""):
     os.environ["PATH"] = _venv_bin + os.pathsep + os.environ.get("PATH", "")
@@ -41,8 +33,9 @@ def build_export_command(
     ratio: float | None = None,
     sym: bool | None = None,
 ) -> list[str]:
-    """Construct the ``optimum-cli export openvino`` argument list."""
-    cmd = [
+    """Construct the ``optimum-cli export openvino`` command."""
+
+    command = [
         "optimum-cli",
         "export",
         "openvino",
@@ -52,18 +45,18 @@ def build_export_command(
         weight_format,
     ]
     if task:
-        cmd += ["--task", task]
+        command += ["--task", task]
     if trust_remote_code:
-        cmd.append("--trust-remote-code")
+        command.append("--trust-remote-code")
     if weight_format == "int4":
         if group_size is not None:
-            cmd += ["--group-size", str(group_size)]
+            command += ["--group-size", str(group_size)]
         if ratio is not None:
-            cmd += ["--ratio", str(ratio)]
+            command += ["--ratio", str(ratio)]
         if sym:
-            cmd.append("--sym")
-    cmd.append(str(output_dir))
-    return cmd
+            command.append("--sym")
+    command.append(str(output_dir))
+    return command
 
 
 def export_model(
@@ -77,11 +70,8 @@ def export_model(
     ratio: float | None = None,
     sym: bool | None = None,
 ) -> Path:
-    """Run the export and return the output directory.
+    """Run an export and return its output directory."""
 
-    Raises ``RuntimeError`` if ``optimum-cli`` is not installed and
-    ``subprocess.CalledProcessError`` if the export itself fails.
-    """
     if shutil.which("optimum-cli") is None:
         raise RuntimeError(
             "optimum-cli not found. Install conversion deps: "
@@ -96,7 +86,7 @@ def export_model(
             "the Hugging Face repo during conversion. Only use this with models you trust.",
             source_model,
         )
-    cmd = build_export_command(
+    command = build_export_command(
         source_model,
         output_dir,
         weight_format,
@@ -106,8 +96,8 @@ def export_model(
         ratio=ratio,
         sym=sym,
     )
-    logger.info("Running: %s", " ".join(cmd))
-    subprocess.run(cmd, check=True)
+    logger.info("Running: %s", " ".join(command))
+    subprocess.run(command, check=True)
     logger.info("Exported %s -> %s", source_model, output_dir)
     return output_dir
 
@@ -116,6 +106,7 @@ def _resolve_from_catalog(
     model_id: str, *, include_task: bool = False
 ) -> tuple[str, Path, str] | tuple[str, Path, str, str | None]:
     """Look up catalog conversion settings, optionally including the Optimum task."""
+
     from app.config import Settings
     from app.model_registry import load_catalog
 
@@ -128,12 +119,20 @@ def _resolve_from_catalog(
         )
     if not cfg.source_model:
         raise SystemExit(f"Model '{model_id}' has no 'source_model' in models.json")
+
     from app.config import BASE_DIR
 
     result = (cfg.source_model, cfg.abs_path(BASE_DIR), cfg.weight_format)
     if not include_task:
         return result
-    task = "feature-extraction" if "embedding" in cfg.backend.lower() else None
+
+    backend = cfg.backend.lower()
+    if "embedding" in backend:
+        task = "feature-extraction"
+    elif "vlm" in backend or "vision" in backend:
+        task = "image-text-to-text"
+    else:
+        task = None
     return (*result, task)
 
 

--- a/runtime/openvino_engine.py
+++ b/runtime/openvino_engine.py
@@ -1,14 +1,10 @@
-"""Inference engine wrappers.
+"""Inference engine wrappers for text, embeddings, and vision-language models.
 
-``OpenVINOEngine`` wraps ``openvino_genai.LLMPipeline`` (imported lazily).
-``MockEngine`` produces canned, streamed responses so the full server and web UI
-can be exercised on machines without OpenVINO (e.g. macOS during frontend work).
-
-Both expose the same small interface:
-    apply_chat_template(messages, add_generation_prompt) -> str
-    count_tokens(text) -> int
-    generate(prompt, params) -> GenResult
-    stream(prompt, params) -> StreamHandle
+``OpenVINOEngine`` wraps ``openvino_genai.LLMPipeline``.
+``OpenVINOVisionEngine`` wraps ``openvino_genai.VLMPipeline`` and consumes the
+validated image contexts produced by :mod:`app.multimodal`.
+Mock engines preserve the same contracts so API and browser work can be tested on
+machines without OpenVINO hardware.
 """
 
 from __future__ import annotations
@@ -24,7 +20,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from app import chat_format
+from app import chat_format, multimodal
 from runtime.device_check import is_openvino_available, normalize_device
 
 logger = logging.getLogger("ov-llm.engine")
@@ -52,12 +48,7 @@ class GenResult:
 
 
 class StreamHandle:
-    """Thread-safe bridge from a synchronous generation worker to the caller.
-
-    The worker thread calls :meth:`push` / :meth:`finish`; the consumer calls
-    :meth:`next_chunk` (designed to be run via ``run_in_executor`` so the asyncio
-    event loop is never blocked). ``next_chunk`` returns ``None`` at end of stream.
-    """
+    """Thread-safe bridge from a synchronous generation worker to an async caller."""
 
     def __init__(self) -> None:
         self._q: queue.Queue = queue.Queue(maxsize=1024)
@@ -67,12 +58,8 @@ class StreamHandle:
         self._done = threading.Event()
 
     def push(self, piece: str) -> bool:
-        """Queue a generated chunk unless cancellation was requested.
+        """Queue a generated chunk unless cancellation was requested."""
 
-        A bounded queue prevents unbounded memory growth, but a plain blocking
-        ``put`` can deadlock a generation worker after a client disconnects.
-        Polling with a short timeout lets cancellation release the worker.
-        """
         while not self.should_stop():
             try:
                 self._q.put(piece, timeout=0.1)
@@ -92,8 +79,6 @@ class StreamHandle:
                 except queue.Full:
                     if not self.should_stop():
                         continue
-                    # The consumer has gone away. Discard one queued chunk so
-                    # blocked ``next_chunk`` workers can still receive EOF.
                     with contextlib.suppress(queue.Empty):
                         self._q.get_nowait()
         finally:
@@ -104,19 +89,18 @@ class StreamHandle:
         return None if item is _SENTINEL else item
 
     def request_stop(self) -> None:
-        """Ask the worker to stop generating early (e.g. the client disconnected)."""
         self._stop.set()
 
     def should_stop(self) -> bool:
         return self._stop.is_set()
 
     def wait_closed(self, timeout: float | None = 30.0) -> bool:
-        """Block until the worker thread has finished, so the engine is free again."""
         return self._done.wait(timeout)
 
 
 class BaseEngine:
     backend = "base"
+    supports_vision = False
     model_id: str = ""
     model_path: str = ""
     device: str = "CPU"
@@ -143,11 +127,11 @@ class BaseEngine:
         return None
 
 
-# --- Mock engine -----------------------------------------------------------
+# --- Mock engines ----------------------------------------------------------
 
 
 class MockEngine(BaseEngine):
-    """A dependency-free engine that streams a canned reply. For UI/API testing."""
+    """Dependency-free canned text engine for API and UI testing."""
 
     backend = "mock"
 
@@ -157,10 +141,11 @@ class MockEngine(BaseEngine):
         self.device = device
 
     def apply_chat_template(self, messages: list[dict], add_generation_prompt: bool = True) -> str:
+        messages = multimodal.prepare_text_messages(messages)
         return chat_format.render_chatml(messages, add_generation_prompt)
 
     def count_tokens(self, text: str) -> int:
-        return max(1, len(text) // 4)
+        return max(1, len(multimodal.strip_prompt_context(text)) // 4)
 
     def _reply(self, prompt: str) -> str:
         matches = re.findall(r"<\|im_start\|>user\n(.*?)<\|im_end\|>", prompt, re.DOTALL)
@@ -185,7 +170,7 @@ class MockEngine(BaseEngine):
             for token in re.findall(r"\S+\s*", text):
                 if handle.should_stop():
                     break
-                time.sleep(0.015)  # simulate generation latency for the UI
+                time.sleep(0.015)
                 if not handle.push(token):
                     break
             handle.finish()
@@ -194,8 +179,34 @@ class MockEngine(BaseEngine):
         return handle
 
 
+class MockVisionEngine(MockEngine):
+    """Mock VLM that verifies the complete image transport without inference."""
+
+    backend = "mock-vlm"
+    supports_vision = True
+
+    def apply_chat_template(self, messages: list[dict], add_generation_prompt: bool = True) -> str:
+        prepared, context_key = multimodal.prepare_vision_messages(messages)
+        prompt = chat_format.render_chatml(prepared, add_generation_prompt)
+        return multimodal.append_prompt_context(prompt, context_key)
+
+    def _reply(self, prompt: str) -> str:
+        clean_prompt, images = multimodal.consume_prompt_context(prompt)
+        matches = re.findall(r"<\|im_start\|>user\n(.*?)<\|im_end\|>", clean_prompt, re.DOTALL)
+        last_user = matches[-1].strip() if matches else "(no user message found)"
+        last_user = re.sub(r"<ov_genai_image_\d+>", "[image]", last_user)
+        dimensions = ", ".join(f"{item.width}×{item.height}" for item in images) or "none"
+        return (
+            "**Mock vision engine** — OpenVINO VLM inference is not active.\n\n"
+            f"Received **{len(images)} image(s)** ({dimensions}).\n\n"
+            f"Prompt: _{last_user[:400]}_\n\n"
+            "The image validation, OpenAI content-part parsing, model routing, and streaming "
+            "path completed successfully. Load a converted `openvino-vlm` model for real analysis."
+        )
+
+
 class MockEmbeddingEngine(BaseEngine):
-    """A mock engine that yields dummy embeddings (length 384) for testing."""
+    """Mock embedding engine returning deterministic 384-dimensional vectors."""
 
     backend = "mock-embeddings"
 
@@ -215,7 +226,6 @@ class MockEmbeddingEngine(BaseEngine):
 
         results = []
         for text in texts:
-            # Use a stable digest rather than Python's process-randomized hash().
             seed = int.from_bytes(hashlib.sha256(text.encode("utf-8")).digest()[:8], "big")
             rng = random.Random(seed)
             results.append([rng.uniform(-1.0, 1.0) for _ in range(384)])
@@ -225,11 +235,11 @@ class MockEmbeddingEngine(BaseEngine):
         self._closed = True
 
 
-# --- OpenVINO GenAI engine -------------------------------------------------
+# --- OpenVINO text and vision engines -------------------------------------
 
 
 class OpenVINOEngine(BaseEngine):
-    """Wraps ``openvino_genai.LLMPipeline``. Constructed only when OpenVINO exists."""
+    """Wrap ``openvino_genai.LLMPipeline``."""
 
     backend = "openvino-genai"
 
@@ -241,7 +251,7 @@ class OpenVINOEngine(BaseEngine):
         plugin_config: dict | None = None,
         draft_model_path: str | None = None,
     ) -> None:
-        import openvino_genai as ov_genai  # lazy: only imported on a real load
+        import openvino_genai as ov_genai
 
         self._ov = ov_genai
         self.model_id = model_id
@@ -250,7 +260,6 @@ class OpenVINOEngine(BaseEngine):
         self._closed = False
 
         config = dict(plugin_config or {})
-
         draft_obj = None
         if draft_model_path:
             logger.info("Initializing speculative decoding with draft model: %s", draft_model_path)
@@ -282,8 +291,7 @@ class OpenVINOEngine(BaseEngine):
         if self._closed:
             raise RuntimeError(f"Engine for '{self.model_id}' is closed")
 
-    def apply_chat_template(self, messages: list[dict], add_generation_prompt: bool = True) -> str:
-        self._check_closed()
+    def _render_messages(self, messages: list[dict], add_generation_prompt: bool) -> str:
         try:
             try:
                 return self._tokenizer.apply_chat_template(
@@ -292,12 +300,19 @@ class OpenVINOEngine(BaseEngine):
                 )
             except TypeError:
                 return self._tokenizer.apply_chat_template(messages, add_generation_prompt)
-        except Exception as exc:  # model has no chat template, or signature differs
+        except Exception as exc:
             logger.debug("apply_chat_template failed (%s); falling back to ChatML", exc)
             return chat_format.render_chatml(messages, add_generation_prompt)
 
+    def apply_chat_template(self, messages: list[dict], add_generation_prompt: bool = True) -> str:
+        self._check_closed()
+        return self._render_messages(
+            multimodal.prepare_text_messages(messages), add_generation_prompt
+        )
+
     def count_tokens(self, text: str) -> int:
         self._check_closed()
+        text = multimodal.strip_prompt_context(text)
         try:
             ids = self._tokenizer.encode(text).input_ids
             try:
@@ -315,53 +330,50 @@ class OpenVINOEngine(BaseEngine):
             cfg.temperature = float(params.temperature)
             cfg.top_p = float(params.top_p)
             if params.seed is not None:
-                # Attribute name varies across OpenVINO GenAI versions; best effort.
                 with contextlib.suppress(Exception):
                     cfg.rng_seed = int(params.seed)
         else:
             cfg.do_sample = False
         if params.stop:
-            # Let the runtime stop early when supported; the server also truncates
-            # defensively so correctness never depends on this attribute existing.
             with contextlib.suppress(Exception):
                 cfg.stop_strings = set(params.stop)
                 cfg.include_stop_str_in_output = False
         if params.response_format:
-            StructuredOutputConfig = getattr(self._ov, "StructuredOutputConfig", None)
-            if StructuredOutputConfig is not None:
+            structured_output = getattr(self._ov, "StructuredOutputConfig", None)
+            if structured_output is not None:
                 import json
 
-                fmt_type = params.response_format.get("type")
-                if fmt_type == "json_schema":
+                format_type = params.response_format.get("type")
+                if format_type == "json_schema":
                     schema_data = params.response_format.get("json_schema", {}).get("schema")
                     if schema_data:
-                        so_cfg = StructuredOutputConfig(json_schema=json.dumps(schema_data))
+                        output_config = structured_output(json_schema=json.dumps(schema_data))
                         with contextlib.suppress(Exception):
-                            so_cfg.backend = "xgrammar"
-                        cfg.structured_output_config = so_cfg
-                elif fmt_type == "json_object":
-                    so_cfg = StructuredOutputConfig(json_schema=json.dumps({"type": "object"}))
+                            output_config.backend = "xgrammar"
+                        cfg.structured_output_config = output_config
+                elif format_type == "json_object":
+                    output_config = structured_output(json_schema=json.dumps({"type": "object"}))
                     with contextlib.suppress(Exception):
-                        so_cfg.backend = "xgrammar"
-                    cfg.structured_output_config = so_cfg
+                        output_config.backend = "xgrammar"
+                    cfg.structured_output_config = output_config
         return cfg
 
     def _build_adapters_config(self, params: GenParams):
         if not params.lora_path:
             return None
-        Adapter = getattr(self._ov, "Adapter", None)
-        AdapterConfig = getattr(self._ov, "AdapterConfig", None)
-        if Adapter is None or AdapterConfig is None:
+        adapter = getattr(self._ov, "Adapter", None)
+        adapter_config_type = getattr(self._ov, "AdapterConfig", None)
+        if adapter is None or adapter_config_type is None:
             raise RuntimeError(
                 "This OpenVINO GenAI version does not support dynamic LoRA adapters."
             )
         try:
-            adapters_config = AdapterConfig()
-            adapters_config.add(
-                Adapter(str(params.lora_path)),
+            adapter_config = adapter_config_type()
+            adapter_config.add(
+                adapter(str(params.lora_path)),
                 alpha=float(params.lora_alpha or 1.0),
             )
-            return adapters_config
+            return adapter_config
         except Exception as exc:
             raise RuntimeError(
                 f"Failed to construct LoRA adapter config for '{params.lora_path}': {exc}"
@@ -380,11 +392,11 @@ class OpenVINOEngine(BaseEngine):
     def stream(self, prompt: str, params: GenParams) -> StreamHandle:
         self._check_closed()
         handle = StreamHandle()
-        cfg = self._build_config(params)
+        config = self._build_config(params)
         pipe = self._pipe
 
         def streamer(subword: str) -> bool:
-            return not handle.push(subword)  # True => stop generation, False => keep going
+            return not handle.push(subword)
 
         def worker() -> None:
             try:
@@ -392,7 +404,7 @@ class OpenVINOEngine(BaseEngine):
                 adapters_config = self._build_adapters_config(params)
                 if adapters_config is not None:
                     kwargs["adapters"] = adapters_config
-                pipe.generate(prompt, cfg, streamer, **kwargs)
+                pipe.generate(prompt, config, streamer, **kwargs)
             except BaseException as exc:  # noqa: BLE001 - surface to the consumer
                 handle.finish(error=exc)
                 return
@@ -410,8 +422,111 @@ class OpenVINOEngine(BaseEngine):
         self._tokenizer = None
 
 
+class OpenVINOVisionEngine(OpenVINOEngine):
+    """Wrap ``openvino_genai.VLMPipeline`` for OpenAI-compatible image inputs."""
+
+    backend = "openvino-vlm"
+    supports_vision = True
+
+    def __init__(
+        self,
+        model_id: str,
+        model_path: str,
+        device: str,
+        plugin_config: dict | None = None,
+        draft_model_path: str | None = None,
+    ) -> None:
+        if draft_model_path:
+            raise RuntimeError("Speculative draft models are not supported by the VLM backend.")
+
+        import openvino_genai as ov_genai
+
+        if not hasattr(ov_genai, "VLMPipeline"):
+            raise RuntimeError(
+                "This OpenVINO GenAI version does not provide VLMPipeline. Upgrade openvino-genai."
+            )
+
+        self._ov = ov_genai
+        self.model_id = model_id
+        self.model_path = str(model_path)
+        self.device = normalize_device(device)
+        self._closed = False
+        config = dict(plugin_config or {})
+
+        logger.info("Loading vision model '%s' on %s from %s", model_id, self.device, self.model_path)
+        if self.device == "NPU" and config:
+            # VLM NPU plugin options are nested under DEVICE_PROPERTIES.
+            self._pipe = ov_genai.VLMPipeline(
+                self.model_path,
+                self.device,
+                config={"DEVICE_PROPERTIES": {"NPU": config}},
+            )
+        elif config:
+            self._pipe = ov_genai.VLMPipeline(self.model_path, self.device, **config)
+        else:
+            self._pipe = ov_genai.VLMPipeline(self.model_path, self.device)
+        self._tokenizer = self._pipe.get_tokenizer()
+        logger.info("Vision model '%s' ready on %s", model_id, self.device)
+
+    def apply_chat_template(self, messages: list[dict], add_generation_prompt: bool = True) -> str:
+        self._check_closed()
+        prepared, context_key = multimodal.prepare_vision_messages(messages)
+        prompt = self._render_messages(prepared, add_generation_prompt)
+        return multimodal.append_prompt_context(prompt, context_key)
+
+    def _generation_inputs(self, prompt: str) -> tuple[str, list[Any]]:
+        clean_prompt, payloads = multimodal.consume_prompt_context(prompt)
+        return clean_prompt, multimodal.to_openvino_tensors(payloads)
+
+    def _build_adapters_config(self, params: GenParams):
+        if params.lora_path:
+            raise RuntimeError("Dynamic LoRA adapters are not supported by the VLM backend.")
+        return None
+
+    def generate(self, prompt: str, params: GenParams) -> GenResult:
+        self._check_closed()
+        clean_prompt, images = self._generation_inputs(prompt)
+        kwargs: dict[str, Any] = {"generation_config": self._build_config(params)}
+        if images:
+            kwargs["images"] = images
+        result = self._pipe.generate(clean_prompt, **kwargs)
+        text = _result_text(result)
+        return GenResult(text=text, completion_tokens=self.count_tokens(text))
+
+    def stream(self, prompt: str, params: GenParams) -> StreamHandle:
+        self._check_closed()
+        clean_prompt, images = self._generation_inputs(prompt)
+        handle = StreamHandle()
+        config = self._build_config(params)
+        pipe = self._pipe
+
+        def streamer(subword: str) -> bool:
+            return not handle.push(subword)
+
+        def worker() -> None:
+            try:
+                kwargs: dict[str, Any] = {
+                    "generation_config": config,
+                    "streamer": streamer,
+                }
+                if images:
+                    kwargs["images"] = images
+                pipe.generate(clean_prompt, **kwargs)
+            except BaseException as exc:  # noqa: BLE001 - surface to the consumer
+                handle.finish(error=exc)
+                return
+            handle.finish()
+
+        threading.Thread(target=worker, daemon=True).start()
+        return handle
+
+
+# --- Embedding engine ------------------------------------------------------
+
+
 def _result_text(result) -> str:
-    """Extract generated text from an ov_genai result, defensively."""
+    """Extract generated text from an OpenVINO decoded result defensively."""
+
     try:
         if hasattr(result, "texts") and result.texts:
             return str(result.texts[0])
@@ -421,7 +536,7 @@ def _result_text(result) -> str:
 
 
 class OpenVINOEmbeddingEngine(BaseEngine):
-    """Wraps ``openvino_genai.TextEmbeddingPipeline``. Constructed only when OpenVINO exists."""
+    """Wrap ``openvino_genai.TextEmbeddingPipeline``."""
 
     backend = "openvino-embeddings"
 
@@ -461,40 +576,37 @@ class OpenVINOEmbeddingEngine(BaseEngine):
     def embed(self, texts: list[str]) -> list[list[float]]:
         self._check_closed()
         if hasattr(self._pipe, "embed_documents"):
-            res = self._pipe.embed_documents(texts)
+            result = self._pipe.embed_documents(texts)
         elif hasattr(self._pipe, "embed"):
-            res = self._pipe.embed(texts)
+            result = self._pipe.embed(texts)
         else:
             raise AttributeError(
                 "OpenVINO TextEmbeddingPipeline does not have 'embed_documents' or 'embed' methods."
             )
 
-        # Defensively convert the returned object (numpy array, ov.Tensor or list of lists)
-        # to a standard Python list of lists of floats.
-        if hasattr(res, "tolist"):
-            return res.tolist()
-        if hasattr(res, "embeddings"):
-            embeddings = res.embeddings
+        if hasattr(result, "tolist"):
+            return result.tolist()
+        if hasattr(result, "embeddings"):
+            embeddings = result.embeddings
             if hasattr(embeddings, "tolist"):
                 return embeddings.tolist()
         try:
             import numpy as np
 
-            return np.array(res).tolist()
+            return np.array(result).tolist()
         except Exception:
             pass
 
-        # Manual conversion fallback
-        result = []
-        for row in res:
+        output = []
+        for row in result:
             if hasattr(row, "tolist"):
-                result.append(row.tolist())
+                output.append(row.tolist())
             else:
                 try:
-                    result.append([float(x) for x in row])
+                    output.append([float(value) for value in row])
                 except Exception:
-                    result.append(float(row))
-        return result
+                    output.append(float(row))
+        return output
 
     def close(self) -> None:
         if self._closed:
@@ -512,13 +624,8 @@ def build_plugin_config(
     max_prompt_len: int | None,
     cache_dir: str | Path | None = None,
 ) -> dict:
-    """Device-specific OpenVINO plugin config.
+    """Build device-specific OpenVINO plugin configuration."""
 
-    The NPU plugin compiles to static shapes and benefits from an explicit prompt
-    length bound. Composite targets such as ``AUTO:NPU,GPU,CPU`` intentionally
-    use OpenVINO GenAI defaults because plugin-option behavior can differ across
-    routed devices.
-    """
     device = normalize_device(device)
     config: dict = {}
     if device == "NPU" and max_prompt_len:
@@ -546,26 +653,39 @@ def create_engine(
     backend: str = "openvino-genai",
     draft_model_path: str | None = None,
 ) -> BaseEngine:
-    """Create the appropriate engine for the current environment.
+    """Create the configured text, embedding, or vision engine."""
 
-    Falls back to :class:`MockEngine` when OpenVINO is unavailable or mock mode is
-    forced, so the server stays usable for frontend/API work everywhere.
-    """
     device = normalize_device(device)
-    is_embedding = "embedding" in backend.lower()
+    backend_lower = backend.lower()
+    is_embedding = "embedding" in backend_lower
+    is_vision = multimodal.backend_supports_vision(backend_lower)
 
     if force_mock or not is_openvino_available():
         reason = "forced" if force_mock else "OpenVINO not installed"
         if is_embedding:
             logger.info("Using MOCK embedding engine for '%s' (%s)", model_id, reason)
             return MockEmbeddingEngine(model_id, model_path, device if force_mock else "MOCK")
-        else:
-            logger.info("Using MOCK engine for '%s' (%s)", model_id, reason)
-            return MockEngine(model_id, model_path, device if force_mock else "MOCK")
+        if is_vision:
+            logger.info("Using MOCK vision engine for '%s' (%s)", model_id, reason)
+            return MockVisionEngine(model_id, model_path, device if force_mock else "MOCK")
+        logger.info("Using MOCK engine for '%s' (%s)", model_id, reason)
+        return MockEngine(model_id, model_path, device if force_mock else "MOCK")
 
     plugin_config = build_plugin_config(device, max_prompt_len, cache_dir)
     if is_embedding:
         return OpenVINOEmbeddingEngine(model_id, model_path, device, plugin_config)
+    if is_vision:
+        return OpenVINOVisionEngine(
+            model_id,
+            model_path,
+            device,
+            plugin_config,
+            draft_model_path=draft_model_path,
+        )
     return OpenVINOEngine(
-        model_id, model_path, device, plugin_config, draft_model_path=draft_model_path
+        model_id,
+        model_path,
+        device,
+        plugin_config,
+        draft_model_path=draft_model_path,
     )

--- a/runtime/openvino_engine.py
+++ b/runtime/openvino_engine.py
@@ -453,7 +453,9 @@ class OpenVINOVisionEngine(OpenVINOEngine):
         self._closed = False
         config = dict(plugin_config or {})
 
-        logger.info("Loading vision model '%s' on %s from %s", model_id, self.device, self.model_path)
+        logger.info(
+            "Loading vision model '%s' on %s from %s", model_id, self.device, self.model_path
+        )
         if self.device == "NPU" and config:
             # VLM NPU plugin options are nested under DEVICE_PROPERTIES.
             self._pipe = ov_genai.VLMPipeline(

--- a/scripts/validate_api_contract.py
+++ b/scripts/validate_api_contract.py
@@ -11,10 +11,11 @@ import sys
 import time
 import urllib.error
 import urllib.request
+from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 _SECRET_RE = re.compile(
     r"Bearer\s+\S+|hf_[A-Za-z0-9_=-]{8,}|token\s*[:=]\s*\S+",
@@ -75,9 +76,7 @@ class Client:
                 exc.read(),
             )
         except urllib.error.URLError as exc:
-            raise ValidationError(
-                f"Cannot reach {request.full_url}: {exc.reason}"
-            ) from exc
+            raise ValidationError(f"Cannot reach {request.full_url}: {exc.reason}") from exc
 
     def json(
         self,
@@ -90,17 +89,13 @@ class Client:
     ) -> Any:
         status, _, body = self.request(method, path, payload, auth=auth)
         if status not in expected:
-            raise ValidationError(
-                f"{method} {path} returned HTTP {status}: {body[:400]!r}"
-            )
+            raise ValidationError(f"{method} {path} returned HTTP {status}: {body[:400]!r}")
         try:
             return json.loads(body.decode())
         except json.JSONDecodeError as exc:
             raise ValidationError(f"{method} {path} returned invalid JSON") from exc
 
-    def sse(
-        self, path: str, payload: dict[str, Any], *, first_event_only: bool = False
-    ) -> str:
+    def sse(self, path: str, payload: dict[str, Any], *, first_event_only: bool = False) -> str:
         request = urllib.request.Request(
             f"{self.base_url}{path}",
             data=json.dumps(payload).encode(),
@@ -167,9 +162,7 @@ class Validator:
         except Exception as exc:  # noqa: BLE001
             status, detail = "fail", sanitize(exc, self.args.api_key)
         self.checks.append(
-            Check(
-                name, status, round((time.perf_counter() - started) * 1000, 1), detail
-            )
+            Check(name, status, round((time.perf_counter() - started) * 1000, 1), detail)
         )
 
     def wait(self) -> None:
@@ -222,9 +215,7 @@ class Validator:
         ids = {item.get("id") for item in data.get("data", [])}
         require(self.args.model in ids, f"Missing model {self.args.model}")
         if self.args.include_embeddings:
-            require(
-                self.args.embedding_model in ids, "Embedding model is not cataloged"
-            )
+            require(self.args.embedding_model in ids, "Embedding model is not cataloged")
         return f"catalog={len(ids)}"
 
     def load(self, model: str, device: str | None) -> str:
@@ -286,9 +277,7 @@ class Validator:
             "/v1/chat/completions",
             {
                 "model": self.args.model,
-                "messages": [
-                    {"role": "user", "content": "Generate several sentences."}
-                ],
+                "messages": [{"role": "user", "content": "Generate several sentences."}],
                 "stream": True,
                 "max_tokens": 128,
             },
@@ -333,9 +322,7 @@ class Validator:
                 "max_tokens": 48,
             },
         )
-        content = (
-            (json_data.get("choices") or [{}])[0].get("message", {}).get("content")
-        )
+        content = (json_data.get("choices") or [{}])[0].get("message", {}).get("content")
         strict_json = False
         try:
             strict_json = isinstance(json.loads(content or ""), dict)
@@ -376,9 +363,7 @@ class Validator:
             "response.output_text.delta",
             "response.completed",
         }
-        require(
-            done and required.issubset(events), "Responses SSE sequence is incomplete"
-        )
+        require(done and required.issubset(events), "Responses SSE sequence is incomplete")
         return "streaming and non-streaming passed"
 
     def embeddings(self) -> str | tuple[str, str]:
@@ -406,9 +391,7 @@ class Validator:
     def benchmark(self) -> str | tuple[str, str]:
         if not self.args.run_benchmark:
             return "skip", "Not requested"
-        status, _, _ = self.client.request(
-            "POST", "/v1/models/unload", {"model": self.args.model}
-        )
+        status, _, _ = self.client.request("POST", "/v1/models/unload", {"model": self.args.model})
         require(status == 200, f"Benchmark preflight unload returned HTTP {status}")
         try:
             data = self.client.json(
@@ -430,9 +413,7 @@ class Validator:
     def lifecycle(self) -> str | tuple[str, str]:
         if not self.args.exercise_lifecycle:
             return "skip", "Not requested"
-        status, _, _ = self.client.request(
-            "POST", "/v1/models/unload", {"model": self.args.model}
-        )
+        status, _, _ = self.client.request("POST", "/v1/models/unload", {"model": self.args.model})
         require(status == 200, f"Unload returned HTTP {status}")
         status, _, _ = self.client.request(
             "POST",
@@ -469,9 +450,7 @@ class Validator:
             "generated_at": datetime.now(UTC).isoformat(),
             "profile": self.args.profile,
             "model": self.args.model,
-            "embedding_model": self.args.embedding_model
-            if self.args.include_embeddings
-            else None,
+            "embedding_model": self.args.embedding_model if self.args.include_embeddings else None,
             "requested_device": self.args.device,
             "server": self.server,
             "summary": summary,
@@ -512,9 +491,7 @@ def markdown(report: dict[str, Any]) -> str:
 def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(description=__doc__)
     result.add_argument("--base-url", default="http://127.0.0.1:8000")
-    result.add_argument(
-        "--profile", choices=("core", "openwebui", "n8n", "full"), default="full"
-    )
+    result.add_argument("--profile", choices=("core", "openwebui", "n8n", "full"), default="full")
     result.add_argument("--model", default="tinyllama-1.1b-chat-fp16")
     result.add_argument("--embedding-model", default="bge-small-en-v1.5")
     result.add_argument("--device")
@@ -546,9 +523,7 @@ def main(argv: list[str] | None = None) -> int:
     rendered = markdown(report)
     if args.output_json:
         args.output_json.parent.mkdir(parents=True, exist_ok=True)
-        args.output_json.write_text(
-            json.dumps(report, indent=2) + "\n", encoding="utf-8"
-        )
+        args.output_json.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
     if args.output_markdown:
         args.output_markdown.parent.mkdir(parents=True, exist_ok=True)
         args.output_markdown.write_text(rendered, encoding="utf-8")

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -1,0 +1,184 @@
+import base64
+import io
+
+import pytest
+from PIL import Image
+from pydantic import ValidationError
+
+from app import chat_format, multimodal
+from app.model_registry import ModelConfig, make_catalog_entry
+from app.openai_api import ChatCompletionRequest, ChatMessage, ResponseRequest
+from runtime.openvino_engine import MockVisionEngine, create_engine
+
+
+def image_data_url(fmt: str = "PNG", size: tuple[int, int] = (3, 2)) -> str:
+    buffer = io.BytesIO()
+    Image.new("RGB", size, (12, 34, 56)).save(buffer, format=fmt)
+    mime = {"PNG": "image/png", "JPEG": "image/jpeg", "WEBP": "image/webp"}[fmt]
+    return f"data:{mime};base64,{base64.b64encode(buffer.getvalue()).decode('ascii')}"
+
+
+def multimodal_content(url: str | None = None) -> list[dict]:
+    return [
+        {"type": "text", "text": "Describe this image."},
+        {"type": "image_url", "image_url": {"url": url or image_data_url()}},
+    ]
+
+
+def test_decode_data_url_verifies_type_and_dimensions():
+    payload = multimodal.decode_data_url(image_data_url(size=(7, 5)))
+    assert payload.mime_type == "image/png"
+    assert (payload.width, payload.height) == (7, 5)
+    assert payload.data.startswith(b"\x89PNG")
+
+
+def test_remote_and_mismatched_image_inputs_are_rejected():
+    with pytest.raises(ValueError, match="remote image URLs are not fetched"):
+        multimodal.decode_data_url("https://example.com/image.png")
+
+    jpeg = image_data_url("JPEG").replace("data:image/jpeg", "data:image/png", 1)
+    with pytest.raises(ValueError, match="not the declared image/png"):
+        multimodal.decode_data_url(jpeg)
+
+
+def test_openai_request_models_validate_image_parts():
+    request = ChatCompletionRequest(
+        model="vision",
+        messages=[ChatMessage(role="user", content=multimodal_content())],
+    )
+    assert request.messages[0].content[1]["type"] == "image_url"
+
+    response_request = ResponseRequest(
+        model="vision",
+        input=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "What is shown?"},
+                    {"type": "input_image", "image_url": image_data_url()},
+                ],
+            }
+        ],
+    )
+    assert response_request.input[0]["content"][1]["type"] == "input_image"
+
+    with pytest.raises(ValidationError, match="base64 data URL"):
+        ChatCompletionRequest(
+            model="vision",
+            messages=[
+                ChatMessage(
+                    role="user",
+                    content=multimodal_content("https://example.com/private.png"),
+                )
+            ],
+        )
+
+
+def test_transport_markers_become_openvino_image_tags_and_are_consumed_once():
+    messages = chat_format.normalize_messages(
+        [ChatMessage(role="user", content=multimodal_content())]
+    )
+    assert "<ovllm-image>" in messages[0]["content"]
+
+    prepared, context_key = multimodal.prepare_vision_messages(messages)
+    assert context_key
+    assert "<ov_genai_image_0>" in prepared[0]["content"]
+    prompt = multimodal.append_prompt_context(
+        chat_format.render_chatml(prepared), context_key
+    )
+
+    clean_prompt, payloads = multimodal.consume_prompt_context(prompt)
+    assert "ovllm-image-context" not in clean_prompt
+    assert len(payloads) == 1
+    assert (payloads[0].width, payloads[0].height) == (3, 2)
+
+    with pytest.raises(RuntimeError, match="expired"):
+        multimodal.consume_prompt_context(prompt)
+
+
+def test_text_model_never_receives_encoded_image_bytes():
+    messages = chat_format.normalize_messages(
+        [ChatMessage(role="user", content=multimodal_content())]
+    )
+    prepared = multimodal.prepare_text_messages(messages)
+    assert "data:image" not in prepared[0]["content"]
+    assert "not vision-capable" in prepared[0]["content"]
+
+
+def test_mock_vision_engine_generates_and_streams_image_summary():
+    engine = MockVisionEngine("mock-vision")
+    messages = chat_format.normalize_messages(
+        [ChatMessage(role="user", content=multimodal_content())]
+    )
+
+    prompt = engine.apply_chat_template(messages)
+    result = engine.generate(prompt, params=type("Params", (), {})())
+    assert "1 image(s)" in result.text
+    assert "3×2" in result.text
+
+    second_prompt = engine.apply_chat_template(messages)
+    stream = engine.stream(second_prompt, params=type("Params", (), {})())
+    chunks = []
+    while True:
+        chunk = stream.next_chunk()
+        if chunk is None:
+            break
+        chunks.append(chunk)
+    assert "1 image(s)" in "".join(chunks)
+    assert stream.error is None
+
+
+def test_factory_and_catalog_expose_vision_capability():
+    engine = create_engine(
+        model_id="mock-vision",
+        model_path="models/openvino/mock-vision",
+        device="CPU",
+        force_mock=True,
+        backend="openvino-vlm",
+    )
+    assert engine.supports_vision is True
+    assert engine.backend == "mock-vlm"
+
+    config = ModelConfig(
+        id="vision",
+        name="Vision",
+        description="Local VLM",
+        backend="openvino-vlm",
+        model_path="models/openvino/vision",
+        source_model="org/model",
+        weight_format="int4",
+        recommended_device="GPU",
+        max_context_len=4096,
+        max_output_tokens=512,
+    )
+    entry = make_catalog_entry(
+        config,
+        loaded=False,
+        queued=False,
+        loading=False,
+        downloaded=False,
+    )
+    assert entry["supports_vision"] is True
+    assert entry["capabilities"] == ["chat", "vision"]
+    assert entry["input_modalities"] == ["text", "image"]
+
+
+def test_budgeting_keeps_only_returned_prompt_context():
+    engine = MockVisionEngine("mock-vision")
+    messages = chat_format.normalize_messages(
+        [
+            ChatMessage(role="user", content="old " * 200),
+            ChatMessage(role="assistant", content="reply " * 200),
+            ChatMessage(role="user", content=multimodal_content()),
+        ]
+    )
+    prompt, tokens = chat_format.build_prompt_within_budget(
+        messages,
+        engine.apply_chat_template,
+        engine.count_tokens,
+        max_prompt_len=100,
+    )
+    assert tokens > 0
+    clean_prompt, payloads = multimodal.consume_prompt_context(prompt)
+    assert "Describe this image" in clean_prompt
+    assert len(payloads) == 1

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -83,9 +83,7 @@ def test_transport_markers_become_openvino_image_tags_and_are_consumed_once():
     prepared, context_key = multimodal.prepare_vision_messages(messages)
     assert context_key
     assert "<ov_genai_image_0>" in prepared[0]["content"]
-    prompt = multimodal.append_prompt_context(
-        chat_format.render_chatml(prepared), context_key
-    )
+    prompt = multimodal.append_prompt_context(chat_format.render_chatml(prepared), context_key)
 
     clean_prompt, payloads = multimodal.consume_prompt_context(prompt)
     assert "ovllm-image-context" not in clean_prompt

--- a/tests/test_ui_extension.py
+++ b/tests/test_ui_extension.py
@@ -1,0 +1,25 @@
+from app.ui_extension import VISION_EXTENSION_JS, inject_multimodal_ui
+
+
+def test_vision_extension_is_injected_once_before_body_close():
+    html = "<html><body><main>chat</main></body></html>"
+    injected = inject_multimodal_ui(html)
+    assert 'id="ovllm-vision-extension"' in injected
+    assert injected.index('id="ovllm-vision-extension"') < injected.index("</body>")
+    assert inject_multimodal_ui(injected) == injected
+
+
+def test_browser_extension_supports_file_paste_drop_and_openai_image_parts():
+    assert "vision-file-input" in VISION_EXTENSION_JS
+    assert "dragover" in VISION_EXTENSION_JS
+    assert "clipboardData" in VISION_EXTENSION_JS
+    assert "image_url" in VISION_EXTENSION_JS
+    assert "openvino-vlm" in VISION_EXTENSION_JS
+    assert "image-text-to-text" in VISION_EXTENSION_JS
+    assert "supports_vision" in VISION_EXTENSION_JS
+
+
+def test_browser_extension_does_not_upload_images_to_a_separate_endpoint():
+    assert "/v1/images" not in VISION_EXTENSION_JS
+    assert "FileReader" in VISION_EXTENSION_JS
+    assert "dataUrl" in VISION_EXTENSION_JS

--- a/tests/test_web_ui_ux.py
+++ b/tests/test_web_ui_ux.py
@@ -2,9 +2,7 @@
 
 from pathlib import Path
 
-HTML = (Path(__file__).resolve().parents[1] / "web" / "index.html").read_text(
-    encoding="utf-8"
-)
+HTML = (Path(__file__).resolve().parents[1] / "web" / "index.html").read_text(encoding="utf-8")
 
 
 def test_mobile_and_touch_ergonomics_are_preserved() -> None:


### PR DESCRIPTION
## Summary

Adds local image understanding to the OpenVINO server and built-in browser interface through an `openvino-vlm` backend backed by OpenVINO GenAI `VLMPipeline`.

## What changed

- accept OpenAI Chat Completions `image_url` parts and Responses API `input_image` parts
- validate local JPEG, PNG, and WebP data URLs with strict size, count, decoded-pixel, and MIME limits
- reject remote image fetching to preserve the local privacy boundary and avoid SSRF behavior
- add `OpenVINOVisionEngine` and a deterministic mock VLM with streaming support
- route VLM conversion through Optimum's `image-text-to-text` task
- expose model capabilities and input modalities through system status
- add browser file selection, screenshot paste, drag and drop, previews, removal, and model-aware attachment controls
- add custom VLM registration and Hugging Face VLM search options
- avoid retaining image bytes in browser conversation history or on disk
- add regression tests and setup/API documentation
- apply the current Ruff formatter/import normalization required by CI to two existing validation/test files

## Validation

- Ruff lint and format checks passed
- pytest passed on Python 3.11, 3.12, and 3.13
- external OpenAI-compatible API contract smoke suite passed
- Windows PowerShell certification-harness syntax validation passed

Mock mode covers image validation, OpenAI request parsing, prompt transport, prompt-budget context cleanup, VLM model routing, browser extension injection, non-streaming generation, and streaming generation.

Real CPU, GPU, and NPU support remains subject to model/runtime compatibility and the existing Windows hardware certification process.

## Security boundaries

- data URLs only; no arbitrary remote URL fetches
- maximum 4 images per request
- maximum 10 MiB per image and 24 MiB combined
- maximum 25,000,000 decoded pixels per image
- short-lived request-local contexts consumed once
- base64 image bytes removed before text-only tokenizers