### PR TITLE
Harden model lifecycle and preparation UX

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -70,11 +70,15 @@ class Settings:
     max_request_body_mb: int = 40
 
     def __post_init__(self) -> None:
-        # ModelManager imports Settings, so install this lifecycle extension only
-        # when a Settings instance is created, after the manager class is defined.
+        # ModelManager imports Settings, so install lifecycle extensions only when
+        # a Settings instance is created, after the manager class is defined.
+        # Target routing must be installed before cross-operation coordination so
+        # the latter wraps the authoritative load implementation.
+        from app.lifecycle_safety import install_model_lifecycle_safety
         from app.model_load_target import install_model_load_target_routing
 
         install_model_load_target_routing()
+        install_model_lifecycle_safety()
 
     @classmethod
     def from_env(cls) -> Settings:

--- a/app/lifecycle_safety.py
+++ b/app/lifecycle_safety.py
@@ -1,0 +1,228 @@
+"""Cross-operation model lifecycle guards.
+
+Model preparation is asynchronous, so load, convert, delete, and shutdown requests can
+otherwise race one another. This extension serializes the user intent without changing
+the public API: loads requested during conversion are resumed afterward, destructive
+deletes are rejected while work is active, and shutdown never starts a deferred load.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+_INSTALL_FLAG = "_MODEL_LIFECYCLE_SAFETY_INSTALLED"
+_FOLLOWUPS_ATTR = "_post_conversion_loads"
+_CALLBACKS_ATTR = "_post_conversion_callbacks"
+_SHUTTING_DOWN_ATTR = "_model_manager_shutting_down"
+
+
+def _mapping(manager: Any, name: str) -> dict:
+    value = getattr(manager, name, None)
+    if value is None:
+        value = {}
+        setattr(manager, name, value)
+    return value
+
+
+def install_model_lifecycle_safety() -> None:
+    """Install conversion/load/delete coordination on ``ModelManager``."""
+
+    from app import model_manager as manager_module
+    from runtime import device_check
+
+    manager_class = manager_module.ModelManager
+    if getattr(manager_class, _INSTALL_FLAG, False):
+        return
+
+    original_schedule_load = manager_class.schedule_load
+    original_schedule_convert = manager_class.schedule_convert
+    original_delete = manager_class.delete
+    original_shutdown = manager_class.shutdown
+
+    def _active(task: asyncio.Task | None) -> bool:
+        return bool(task and not task.done())
+
+    def _remember_post_conversion_load(
+        self,
+        model_id: str,
+        task: asyncio.Task,
+        device: str,
+        draft_model: str | None,
+    ) -> None:
+        followups = _mapping(self, _FOLLOWUPS_ATTR)
+        callbacks = _mapping(self, _CALLBACKS_ATTR)
+        followups[model_id] = {
+            "device": device,
+            "draft_model": draft_model,
+        }
+
+        if callbacks.get(model_id) is task:
+            return
+        callbacks[model_id] = task
+
+        def resume_after_conversion(done: asyncio.Task) -> None:
+            if callbacks.get(model_id) is not done:
+                return
+            callbacks.pop(model_id, None)
+            request = followups.pop(model_id, None)
+            if request is None or getattr(self, _SHUTTING_DOWN_ATTR, False):
+                return
+            if done.cancelled():
+                return
+
+            try:
+                done.result()
+            except Exception:  # noqa: BLE001 - conversion status already contains the safe error
+                return
+
+            status = self.status_overrides.get(model_id, {}).get("status")
+            if status == "error":
+                return
+
+            try:
+                self.schedule_load(
+                    model_id,
+                    request["device"],
+                    draft_model=request["draft_model"],
+                )
+            except Exception as exc:  # noqa: BLE001 - callback cannot return an HTTP error
+                cfg = self.catalog.get(model_id)
+                name = cfg.name if cfg else model_id
+                message = f"Conversion finished, but loading could not start: {exc}"
+                self._set_status(model_id, "error", error=message)
+                self._set_progress(model_id, "error", message)
+                manager_module.logger.exception(
+                    "Failed to resume load for '%s' after conversion",
+                    model_id,
+                )
+                self.emit_event("error", f"Could not load {name} after conversion")
+
+        task.add_done_callback(resume_after_conversion)
+
+    def coordinated_schedule_load(
+        self,
+        model_id: str,
+        device: str | None = None,
+        *,
+        draft_model: str | None = None,
+    ) -> asyncio.Task | None:
+        conversion = self.convert_tasks.get(model_id)
+        if _active(conversion):
+            target = device_check.normalize_device(device or self.settings.device)
+            _remember_post_conversion_load(
+                self,
+                model_id,
+                conversion,
+                target,
+                draft_model,
+            )
+            cfg = self.catalog.get(model_id)
+            name = cfg.name if cfg else model_id
+            current = self.progress.get(model_id, {})
+            phase = str(current.get("phase") or "converting")
+            if phase not in {"queued", "downloading", "converting", "finalizing"}:
+                phase = "converting"
+            self._set_progress(
+                model_id,
+                phase,
+                f"Preparing {name}. It will load on {target} when conversion finishes…",
+                percent=current.get("percent"),
+            )
+            return conversion
+
+        return original_schedule_load(
+            self,
+            model_id,
+            device,
+            draft_model=draft_model,
+        )
+
+    def coordinated_schedule_convert(
+        self,
+        model_id: str,
+        device: str | None = None,
+        *,
+        load_after: bool = True,
+        weight_format: str | None = None,
+        group_size: int | None = None,
+        ratio: float | None = None,
+        sym: bool | None = None,
+        trust_remote_code: bool | None = None,
+    ) -> asyncio.Task | None:
+        existing = self.convert_tasks.get(model_id)
+        target = device_check.normalize_device(device or self.settings.device)
+        if _active(existing):
+            if load_after:
+                _remember_post_conversion_load(
+                    self,
+                    model_id,
+                    existing,
+                    target,
+                    None,
+                )
+            return existing
+
+        # Reset stale elapsed time/logs from a prior attempt. The converter will
+        # populate a fresh bounded log immediately after it is queued.
+        self._clear_progress(model_id)
+        task = original_schedule_convert(
+            self,
+            model_id,
+            target,
+            load_after=False,
+            weight_format=weight_format,
+            group_size=group_size,
+            ratio=ratio,
+            sym=sym,
+            trust_remote_code=trust_remote_code,
+        )
+
+        if load_after:
+            if _active(task):
+                _remember_post_conversion_load(
+                    self,
+                    model_id,
+                    task,
+                    target,
+                    None,
+                )
+            elif model_id in self.catalog:
+                # Already-converted models return no conversion task.
+                return self.schedule_load(model_id, target)
+        return task
+
+    def guarded_delete(self, model_id: str) -> dict:
+        if model_id in self.engines:
+            raise ValueError(f"Model '{model_id}' is loaded. Unload it before deleting.")
+
+        load_task = self.load_tasks.get(model_id)
+        convert_task = self.convert_tasks.get(model_id)
+        status = self.status_overrides.get(model_id, {}).get("status")
+        if (
+            _active(load_task)
+            or _active(convert_task)
+            or status in {"queued", "loading", "queued_convert", "converting"}
+        ):
+            raise ValueError(
+                f"Model '{model_id}' is still being prepared. "
+                "Wait for loading or conversion to finish before deleting its files."
+            )
+
+        _mapping(self, _FOLLOWUPS_ATTR).pop(model_id, None)
+        _mapping(self, _CALLBACKS_ATTR).pop(model_id, None)
+        return original_delete(self, model_id)
+
+    async def shutdown_without_deferred_loads(self) -> None:
+        setattr(self, _SHUTTING_DOWN_ATTR, True)
+        _mapping(self, _FOLLOWUPS_ATTR).clear()
+        try:
+            await original_shutdown(self)
+        finally:
+            _mapping(self, _CALLBACKS_ATTR).clear()
+
+    manager_class.schedule_load = coordinated_schedule_load
+    manager_class.schedule_convert = coordinated_schedule_convert
+    manager_class.delete = guarded_delete
+    manager_class.shutdown = shutdown_without_deferred_loads
+    setattr(manager_class, _INSTALL_FLAG, True)

--- a/app/model_load_target.py
+++ b/app/model_load_target.py
@@ -1,13 +1,9 @@
-"""Keep explicit model load device requests authoritative.
+"""Keep explicit model load device requests authoritative and failure-safe.
 
-A model can be auto-loaded while the browser is starting, or a second load request
-can arrive while the first OpenVINO compilation is still in progress. Historically,
-``ModelManager.schedule_load`` treated either case as an unconditional no-op. That
-meant a later explicit ``NPU`` request could inherit an earlier ``GPU`` load.
-
-This module installs a narrow lifecycle extension that tracks the latest requested
-device per model, safely switches an already-loaded idle engine, and retargets an
-in-flight build before publishing it as ready.
+The newest explicit device request wins, including when a startup load or a previous
+OpenVINO compilation is already in flight. A working engine is retained until its
+replacement has compiled successfully so a bad target or driver failure does not
+silently take the model offline.
 """
 
 from __future__ import annotations
@@ -43,6 +39,84 @@ def install_model_load_target_routing() -> None:
 
     original_shutdown = manager_class.shutdown
 
+    async def _preflight(
+        self,
+        model_id: str,
+        current_device: str,
+    ) -> None:
+        cfg = self.catalog[model_id]
+        self._set_status(model_id, "loading")
+        self._set_progress(
+            model_id,
+            "loading",
+            f"Checking local model files and {current_device} availability for {cfg.name}…",
+        )
+
+        if self.force_mock:
+            return
+
+        available = device_check.available_devices()
+        if not device_check.is_device_available(current_device, available):
+            raise RuntimeError(errors.format_device_error(current_device, available))
+
+        if registry.is_downloaded(cfg, BASE_DIR):
+            return
+
+        if not self.settings.auto_convert:
+            raise RuntimeError(
+                errors.format_model_not_converted(
+                    cfg.name,
+                    str(cfg.abs_path(BASE_DIR)),
+                    cfg.source_model,
+                    weight_format=cfg.weight_format,
+                )
+            )
+
+        manager_module.logger.info(
+            "Model '%s' is not available locally; starting automatic conversion",
+            model_id,
+        )
+        self._set_progress(
+            model_id,
+            "downloading",
+            f"{cfg.name} is not converted yet. Downloading and converting first…",
+        )
+        await self._convert_task(model_id, current_device, load_after=False)
+        self._set_status(model_id, "loading")
+        if not registry.is_downloaded(cfg, BASE_DIR):
+            raise RuntimeError(
+                f"Auto-conversion failed for '{cfg.name}'. Review the preparation details."
+            )
+
+    async def _build_engine_cancellation_safe(
+        self,
+        model_id: str,
+        current_device: str,
+        draft_model_path: str | None,
+    ):
+        """Do not leak a compiled engine when an asyncio task is cancelled.
+
+        ``run_in_executor`` cannot stop an OpenVINO compilation after it has begun.
+        During shutdown, wait for that worker to finish and close its result before
+        propagating cancellation.
+        """
+
+        loop = asyncio.get_running_loop()
+        future = loop.run_in_executor(
+            None,
+            self._build_engine,
+            model_id,
+            current_device,
+            draft_model_path,
+        )
+        try:
+            return await asyncio.shield(future)
+        except asyncio.CancelledError:
+            with contextlib.suppress(Exception):
+                engine = await future
+                engine.close()
+            raise
+
     async def device_authoritative_load_task(
         self,
         model_id: str,
@@ -54,174 +128,198 @@ def install_model_load_target_routing() -> None:
         current_device = device_check.normalize_device(device)
 
         try:
-            try:
-                async with asyncio.timeout(600):
+            while True:
+                current_device = targets.get(model_id, current_device)
+                loaded_engine = self.engines.get(model_id)
+                if loaded_engine is not None:
+                    loaded_device = device_check.normalize_device(loaded_engine.device)
+                    if loaded_device == current_device:
+                        self._set_progress(
+                            model_id,
+                            "ready",
+                            f"{cfg.name} is already loaded on {loaded_device}.",
+                            percent=100,
+                        )
+                        self._clear_status(model_id)
+                        return
+
+                # Validate the requested target and perform any required conversion
+                # before blocking the currently loaded engine. Existing generations
+                # remain usable throughout a long first-time download/conversion.
+                async with self._load_lock:
+                    await _preflight(self, model_id, current_device)
+
+                latest_target = targets.get(model_id, current_device)
+                if latest_target != current_device:
+                    manager_module.logger.info(
+                        "Retargeting queued load for '%s' from %s to %s before compile",
+                        model_id,
+                        current_device,
+                        latest_target,
+                    )
+                    current_device = latest_target
+                    continue
+
+                loaded_engine = self.engines.get(model_id)
+                model_lock = self.locks.get(model_id) if loaded_engine is not None else None
+                if model_lock is not None and model_lock.locked():
+                    loaded_device = device_check.normalize_device(loaded_engine.device)
+                    self._set_status(model_id, "queued")
+                    self._set_progress(
+                        model_id,
+                        "queued",
+                        f"Waiting for the active request before switching {cfg.name} "
+                        f"from {loaded_device} to {current_device}…",
+                    )
+
+                # Acquire the per-model lock before the global load lock. This keeps a
+                # busy model from blocking unrelated model loads while we wait.
+                if model_lock is not None:
+                    await model_lock.acquire()
+
+                replacement = None
+                try:
                     async with self._load_lock:
-                        while True:
-                            current_device = targets.get(model_id, current_device)
-                            loaded_engine = self.engines.get(model_id)
+                        latest_target = targets.get(model_id, current_device)
+                        if latest_target != current_device:
+                            current_device = latest_target
+                            continue
 
-                            if loaded_engine is not None:
-                                loaded_device = device_check.normalize_device(loaded_engine.device)
-                                if loaded_device == current_device:
-                                    self._set_progress(
-                                        model_id,
-                                        "ready",
-                                        f"{cfg.name} is already loaded on {loaded_device}.",
-                                        percent=100,
-                                    )
-                                    self._clear_status(model_id)
-                                    return
-
-                                model_lock = self.locks.get(model_id)
-                                if model_lock and model_lock.locked():
-                                    self._set_status(model_id, "queued")
-                                    self._set_progress(
-                                        model_id,
-                                        "queued",
-                                        f"Waiting to switch {cfg.name} from {loaded_device} "
-                                        f"to {current_device}…",
-                                    )
-                                    async with model_lock:
-                                        pass
-
-                                # Re-check after waiting because a concurrent unload or
-                                # shutdown may have removed the engine.
-                                loaded_engine = self.engines.get(model_id)
-                                if loaded_engine is not None:
-                                    loaded_device = device_check.normalize_device(
-                                        loaded_engine.device
-                                    )
-                                    if loaded_device == current_device:
-                                        self._set_progress(
-                                            model_id,
-                                            "ready",
-                                            f"{cfg.name} is already loaded on {loaded_device}.",
-                                            percent=100,
-                                        )
-                                        self._clear_status(model_id)
-                                        return
-                                    self.unload(model_id)
-                                    manager_module.logger.info(
-                                        "Switching '%s' from %s to %s",
-                                        model_id,
-                                        loaded_device,
-                                        current_device,
-                                    )
-                                    self.emit_event(
-                                        "info",
-                                        f"Switching {cfg.name} from {loaded_device} "
-                                        f"to {current_device}",
-                                    )
-
-                            self._set_status(model_id, "loading")
-                            self._set_progress(
-                                model_id,
-                                "loading",
-                                f"Checking local model files for {cfg.name}…",
-                            )
-
-                            if not self.force_mock:
-                                available = device_check.available_devices()
-                                if not device_check.is_device_available(current_device, available):
-                                    raise RuntimeError(
-                                        errors.format_device_error(current_device, available)
-                                    )
-                                if not registry.is_downloaded(cfg, BASE_DIR):
-                                    if self.settings.auto_convert:
-                                        manager_module.logger.info(
-                                            "Model '%s' not found locally. Auto-convert is enabled. "
-                                            "Starting conversion...",
-                                            model_id,
-                                        )
-                                        self._set_progress(
-                                            model_id,
-                                            "downloading",
-                                            f"{cfg.name} is not converted yet. Downloading and "
-                                            "converting first…",
-                                        )
-                                        await self._convert_task(
-                                            model_id,
-                                            current_device,
-                                            load_after=False,
-                                        )
-                                        self._set_status(model_id, "loading")
-                                        if not registry.is_downloaded(cfg, BASE_DIR):
-                                            raise RuntimeError(
-                                                f"Auto-conversion failed for '{cfg.name}'. "
-                                                "Please check logs."
-                                            )
-                                    else:
-                                        raise RuntimeError(
-                                            errors.format_model_not_converted(
-                                                cfg.name,
-                                                str(cfg.abs_path(BASE_DIR)),
-                                                cfg.source_model,
-                                                weight_format=cfg.weight_format,
-                                            )
-                                        )
-
-                            latest_target = targets.get(model_id, current_device)
-                            if latest_target != current_device:
-                                manager_module.logger.info(
-                                    "Retargeting queued load for '%s' from %s to %s before compile",
-                                    model_id,
-                                    current_device,
-                                    latest_target,
-                                )
-                                current_device = latest_target
-                                continue
-
-                            self._set_progress(
-                                model_id,
-                                "loading",
-                                f"Loading {cfg.name} on {current_device}…",
-                            )
-                            loop = asyncio.get_running_loop()
-                            engine = await loop.run_in_executor(
-                                None,
-                                self._build_engine,
-                                model_id,
-                                current_device,
-                                draft_model_path,
-                            )
-
-                            latest_target = targets.get(model_id, current_device)
-                            if latest_target != current_device:
-                                manager_module.logger.info(
-                                    "Discarding '%s' engine built on %s; newest target is %s",
-                                    model_id,
-                                    current_device,
-                                    latest_target,
-                                )
-                                with contextlib.suppress(Exception):
-                                    engine.close()
+                        loaded_engine = self.engines.get(model_id)
+                        if loaded_engine is not None:
+                            loaded_device = device_check.normalize_device(loaded_engine.device)
+                            if loaded_device == current_device:
                                 self._set_progress(
                                     model_id,
-                                    "loading",
-                                    f"Retargeting {cfg.name} to {latest_target}…",
+                                    "ready",
+                                    f"{cfg.name} is already loaded on {loaded_device}.",
+                                    percent=100,
                                 )
-                                current_device = latest_target
-                                continue
+                                self._clear_status(model_id)
+                                return
 
-                            self.engines[model_id] = engine
-                            self.locks[model_id] = asyncio.Lock()
-                            self.devices[model_id] = engine.device
+                        # Device availability can change while a long generation was
+                        # draining. Recheck the cheap preflight before compiling.
+                        await _preflight(self, model_id, current_device)
+                        latest_target = targets.get(model_id, current_device)
+                        if latest_target != current_device:
+                            current_device = latest_target
+                            continue
+
+                        self._set_status(model_id, "loading")
+                        self._set_progress(
+                            model_id,
+                            "loading",
+                            f"Compiling {cfg.name} for {current_device}…",
+                        )
+                        replacement = await _build_engine_cancellation_safe(
+                            self,
+                            model_id,
+                            current_device,
+                            draft_model_path,
+                        )
+
+                        latest_target = targets.get(model_id, current_device)
+                        if latest_target != current_device:
+                            manager_module.logger.info(
+                                "Discarding '%s' engine built on %s; newest target is %s",
+                                model_id,
+                                current_device,
+                                latest_target,
+                            )
+                            with contextlib.suppress(Exception):
+                                replacement.close()
+                            replacement = None
                             self._set_progress(
                                 model_id,
-                                "ready",
-                                f"{cfg.name} is ready on {engine.device}.",
-                                percent=100,
+                                "loading",
+                                f"Retargeting {cfg.name} to {latest_target}…",
                             )
-                            self._clear_status(model_id)
-                            manager_module.logger.info("Loaded '%s' on %s", model_id, engine.device)
-                            self.emit_event("info", f"Loaded {cfg.name} on {engine.device}")
-                            return
-            except Exception as exc:  # noqa: BLE001 - surfaced through model status
+                            current_device = latest_target
+                            continue
+
+                        previous_engine = self.engines.get(model_id)
+                        previous_device = (
+                            device_check.normalize_device(previous_engine.device)
+                            if previous_engine is not None
+                            else None
+                        )
+
+                        self.engines[model_id] = replacement
+                        self.locks[model_id] = asyncio.Lock()
+                        self.devices[model_id] = replacement.device
+                        replacement = None
+
+                        if previous_engine is not None:
+                            with contextlib.suppress(Exception):
+                                previous_engine.close()
+                            manager_module.logger.info(
+                                "Switched '%s' from %s to %s",
+                                model_id,
+                                previous_device,
+                                self.devices[model_id],
+                            )
+                            self.emit_event(
+                                "info",
+                                f"Switched {cfg.name} from {previous_device} "
+                                f"to {self.devices[model_id]}",
+                            )
+                        else:
+                            manager_module.logger.info(
+                                "Loaded '%s' on %s",
+                                model_id,
+                                self.devices[model_id],
+                            )
+                            self.emit_event(
+                                "info",
+                                f"Loaded {cfg.name} on {self.devices[model_id]}",
+                            )
+
+                        self._set_progress(
+                            model_id,
+                            "ready",
+                            f"{cfg.name} is ready on {self.devices[model_id]}.",
+                            percent=100,
+                        )
+                        self._clear_status(model_id)
+                        return
+                finally:
+                    if replacement is not None:
+                        with contextlib.suppress(Exception):
+                            replacement.close()
+                    if model_lock is not None and model_lock.locked():
+                        model_lock.release()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - surfaced through model status
+            message = errors.format_model_load_error(exc)
+            existing = self.engines.get(model_id)
+            if existing is not None:
+                existing_device = device_check.normalize_device(existing.device)
+                self._clear_status(model_id)
+                self._set_progress(
+                    model_id,
+                    "ready",
+                    f"Could not switch {cfg.name} to {current_device}. "
+                    f"Continuing on {existing_device}. {message}",
+                    percent=100,
+                )
+                manager_module.logger.warning(
+                    "Failed to switch '%s' to %s; retained %s: %s",
+                    model_id,
+                    current_device,
+                    existing_device,
+                    message,
+                )
+                self.emit_event(
+                    "warning",
+                    f"Could not switch {cfg.name} to {current_device}; "
+                    f"continuing on {existing_device}",
+                )
+            else:
                 self.engines.pop(model_id, None)
                 self.locks.pop(model_id, None)
                 self.devices.pop(model_id, None)
-                message = errors.format_model_load_error(exc)
                 self._set_status(model_id, "error", error=message)
                 self._set_progress(model_id, "error", f"Load failed: {message}")
                 manager_module.logger.exception("Failed to load '%s': %s", model_id, message)
@@ -277,28 +375,22 @@ def install_model_load_target_routing() -> None:
             return existing
 
         draft_model_path = self._resolve_draft_model_path(model_id, draft_model)
-
-        # Switch an idle engine immediately so status and API capability flags no
-        # longer report the stale device while the replacement task is queued.
-        if loaded_engine is not None:
-            model_lock = self.locks.get(model_id)
-            if not model_lock or not model_lock.locked():
-                loaded_device = device_check.normalize_device(loaded_engine.device)
-                self.unload(model_id)
-                manager_module.logger.info(
-                    "Unloaded '%s' from %s for requested %s load",
-                    model_id,
-                    loaded_device,
-                    target_device,
-                )
-
         targets[model_id] = target_device
+
+        # A new attempt must not inherit elapsed time or a nearly-complete progress
+        # bar from a previous failed/finished attempt.
+        self._clear_progress(model_id)
         self._set_status(model_id, "queued")
-        self._set_progress(
-            model_id,
-            "queued",
-            f"Queued {cfg.name} to load on {target_device}…",
-        )
+        if loaded_engine is not None:
+            loaded_device = device_check.normalize_device(loaded_engine.device)
+            message = (
+                f"Queued {cfg.name} to switch from {loaded_device} to {target_device}. "
+                f"The current model remains available until the replacement is ready."
+            )
+        else:
+            message = f"Queued {cfg.name} to load on {target_device}…"
+        self._set_progress(model_id, "queued", message)
+
         task = asyncio.create_task(
             self._load_task(
                 model_id,

--- a/app/progress_reliability.py
+++ b/app/progress_reliability.py
@@ -1,8 +1,8 @@
 """Reliable, persistent model-preparation progress for the browser client.
 
-This is the single progress controller used by the UI. It renders optimistic
-feedback immediately after a load/convert request, then reconciles that state with
-the server's model progress on every status poll.
+One controller owns optimistic request feedback and server reconciliation for model
+loads, conversions, and custom-model downloads. It intentionally avoids additional
+fetch wrappers competing for the same DOM surfaces.
 """
 
 from __future__ import annotations
@@ -17,6 +17,11 @@ PROGRESS_RELIABILITY_JS = r"""
     if (window.__ovllmReliableProgressInstalled) return;
     window.__ovllmReliableProgressInstalled = true;
 
+    const PREPARATION_PATHS = new Set([
+        '/v1/models/load',
+        '/v1/models/convert',
+        '/v1/models/download-custom',
+    ]);
     const PHASES = {
         idle: ['Waiting', -1, 0, 0],
         queued: ['Queued', 0, 0, 3],
@@ -28,6 +33,7 @@ PROGRESS_RELIABILITY_JS = r"""
         ready: ['Ready', 3, 100, 100],
         error: ['Failed', -1, 0, 100],
     };
+
     const modelState = new Map();
     const optimistic = new Map();
     let latestStatus = null;
@@ -41,7 +47,7 @@ PROGRESS_RELIABILITY_JS = r"""
         .ovrp-main{width:100%;display:grid;grid-template-columns:auto minmax(0,1fr) auto;gap:7px 10px;align-items:center;padding:11px 12px;border:0;background:transparent;color:inherit;text-align:left;cursor:pointer;font:inherit}
         .ovrp-main:focus-visible{outline:2px solid var(--primary);outline-offset:-2px}.ovrp-spinner{width:16px;height:16px;border:2px solid var(--surface-3);border-top-color:var(--primary);border-radius:50%;animation:spin .8s linear infinite}
         .error .ovrp-spinner{border-color:color-mix(in srgb,var(--red) 28%,var(--surface-3));border-top-color:var(--red);animation:none}.ovrp-copy{min-width:0}
-        .ovrp-title{font-size:11.5px;font-weight:750;color:var(--text-1);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.ovrp-message{margin-top:2px;font-size:10.5px;color:var(--text-3);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+        .ovrp-title{display:block;font-size:11.5px;font-weight:750;color:var(--text-1);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.ovrp-message{display:block;margin-top:2px;font-size:10.5px;color:var(--text-3);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
         .ovrp-value{font-size:11.5px;font-weight:750;color:var(--primary);font-variant-numeric:tabular-nums;white-space:nowrap}.error .ovrp-value{color:var(--red)}
         .ovrp-track{grid-column:2/4;position:relative;height:7px;overflow:hidden;border-radius:999px;background:var(--surface-3);box-shadow:inset 0 0 0 1px var(--border)}
         .ovrp-fill{position:absolute;inset:0 auto 0 0;width:0;border-radius:inherit;background:var(--accent-grad);transition:width .35s ease}.error .ovrp-fill{background:var(--red)}
@@ -122,12 +128,19 @@ PROGRESS_RELIABILITY_JS = r"""
         const raw = phase === 'downloading'
             ? aggregateDownloadPercent(progress) ?? strictPercent(progress.percent)
             : strictPercent(progress.percent);
-        const prior = modelState.get(model.id) || {
+        const reportedStart = Number(progress.started_at) || 0;
+        const previous = modelState.get(model.id);
+        const newOperation = !previous
+            || (reportedStart > 0 && previous.startedAt > 0 && reportedStart !== previous.startedAt)
+            || (previous.terminal && !['ready', 'error'].includes(phase));
+        const prior = newOperation ? {
             overall: 0,
             rank: -1,
-            startedAt: Number(progress.started_at) || Math.floor(Date.now() / 1000),
+            startedAt: reportedStart || Math.floor(Date.now() / 1000),
             targetDevice: null,
-        };
+            terminal: false,
+        } : previous;
+
         let overall = prior.overall;
         let determinate = raw !== null;
         if (phase === 'ready') {
@@ -141,9 +154,10 @@ PROGRESS_RELIABILITY_JS = r"""
         } else {
             overall = Math.max(prior.overall, meta.start);
         }
+
         overall = Math.max(0, Math.min(100, overall));
         const now = Math.floor(Date.now() / 1000);
-        const startedAt = Number(progress.started_at) || prior.startedAt || now;
+        const startedAt = reportedStart || prior.startedAt || now;
         const updatedAt = Number(progress.updated_at) || now;
         const targetDevice = model.device
             || prior.targetDevice
@@ -154,7 +168,9 @@ PROGRESS_RELIABILITY_JS = r"""
             rank: Math.max(prior.rank, meta.stage),
             startedAt,
             targetDevice,
+            terminal: ['ready', 'error'].includes(phase),
         });
+
         return {
             model,
             progress,
@@ -261,7 +277,7 @@ PROGRESS_RELIABILITY_JS = r"""
     function renderDock(model) {
         if (!model || (!model.is_loading && model.status !== 'error')) {
             dock.classList.remove('visible', 'error');
-            return;
+            return null;
         }
         const info = progressInfo(model);
         dock.classList.add('visible');
@@ -312,21 +328,32 @@ PROGRESS_RELIABILITY_JS = r"""
         footer.title = String(info.progress.message || model.status_label || footer.textContent);
     }
 
-    function mergeOptimistic(models) {
+    function mergeOptimistic(source) {
         const now = Date.now();
-        return models.map(model => {
+        const models = source.map(model => {
             const pending = optimistic.get(model.id);
             if (!pending) return model;
             if (model.is_loading || model.is_loaded || model.status === 'error') {
                 optimistic.delete(model.id);
                 return model;
             }
-            if (now - pending.createdAt > 8000) {
+            if (now - pending.createdAt > 15000) {
                 optimistic.delete(model.id);
                 return model;
             }
             return pending.model;
         });
+
+        const known = new Set(models.map(model => model.id));
+        for (const [modelId, pending] of optimistic.entries()) {
+            if (known.has(modelId)) continue;
+            if (now - pending.createdAt > 15000) {
+                optimistic.delete(modelId);
+                continue;
+            }
+            models.push(pending.model);
+        }
+        return models;
     }
 
     function renderStatus(data) {
@@ -372,33 +399,57 @@ PROGRESS_RELIABILITY_JS = r"""
         }
     }
 
-    function parseBody(init) {
-        if (typeof init?.body !== 'string') return {};
-        try {
-            return JSON.parse(init.body);
-        } catch {
-            return {};
-        }
+    function requestMethod(input, init) {
+        return String(init?.method || input?.method || 'GET').toUpperCase();
     }
 
-    function renderOptimistic(path, init) {
-        const body = parseBody(init);
-        const modelId = String(body.model || '');
-        if (!modelId) return;
+    async function requestBody(input, init) {
+        if (typeof init?.body === 'string') {
+            try {
+                return JSON.parse(init.body);
+            } catch {
+                return {};
+            }
+        }
+        if (input instanceof Request) {
+            try {
+                return await input.clone().json();
+            } catch {
+                return {};
+            }
+        }
+        return {};
+    }
+
+    function optimisticIdentity(path, body) {
+        const modelId = String(body.model || body.model_id || '').trim();
+        if (!modelId) return null;
+        return {
+            modelId,
+            device: body.device || body.recommended_device || null,
+            converting: path !== '/v1/models/load',
+        };
+    }
+
+    function renderOptimistic(path, body) {
+        const identity = optimisticIdentity(path, body);
+        if (!identity) return null;
+        const { modelId, device, converting } = identity;
+        modelState.delete(modelId);
+
         const catalog = latestStatus?.models?.available || [];
         const base = catalog.find(model => model.id === modelId) || {
             id: modelId,
-            name: modelId,
+            name: body.name || modelId,
             status_label: 'Preparing model…',
         };
         const now = Math.floor(Date.now() / 1000);
-        const converting = path === '/v1/models/convert';
         const message = converting
             ? `Queued ${baseName(base)} for download and conversion…`
-            : `Queued ${baseName(base)} to load on ${body.device || 'selected device'}…`;
+            : `Queued ${baseName(base)} to load on ${device || 'the selected device'}…`;
         const model = {
             ...base,
-            device: body.device || base.device || null,
+            device: device || base.device || null,
             is_loaded: false,
             is_loading: true,
             status: converting ? 'converting' : 'queued',
@@ -416,42 +467,70 @@ PROGRESS_RELIABILITY_JS = r"""
         const info = renderDock(model);
         renderInline(model, info);
         renderFooter(model, info);
+        return modelId;
+    }
+
+    function clearOptimistic(modelId) {
+        if (!modelId) return;
+        optimistic.delete(modelId);
+        modelState.delete(modelId);
+        if (latestStatus) scheduleRender(latestStatus);
+        else {
+            renderDock(null);
+            renderInline(null, null);
+        }
+    }
+
+    function mergeReturnedModel(payload) {
+        if (!payload?.model) return;
+        const current = latestStatus || { models: { available: [] } };
+        const models = Array.isArray(current.models?.available)
+            ? [...current.models.available]
+            : [];
+        const index = models.findIndex(model => model.id === payload.model.id);
+        if (index >= 0) models[index] = payload.model;
+        else models.push(payload.model);
+        scheduleRender({
+            ...current,
+            models: { ...(current.models || {}), available: models },
+        });
     }
 
     const previousFetch = window.fetch.bind(window);
     window.fetch = async function reliableProgressFetch(input, init = {}) {
         const target = endpoint(input);
-        const method = String(init?.method || 'GET').toUpperCase();
-        if (
-            target.sameOrigin
+        const method = requestMethod(input, init);
+        const isPreparation = target.sameOrigin
             && method === 'POST'
-            && ['/v1/models/load', '/v1/models/convert'].includes(target.path)
-        ) {
-            renderOptimistic(target.path, init);
+            && PREPARATION_PATHS.has(target.path);
+        let optimisticModelId = null;
+
+        if (isPreparation) {
+            const body = await requestBody(input, init);
+            optimisticModelId = renderOptimistic(target.path, body);
         }
 
-        const response = await previousFetch(input, init);
+        let response;
+        try {
+            response = await previousFetch(input, init);
+        } catch (error) {
+            clearOptimistic(optimisticModelId);
+            throw error;
+        }
+
         if (target.sameOrigin && target.path === '/v1/system/status' && response.ok) {
             response.clone().json().then(scheduleRender).catch(() => {});
-        } else if (
-            target.sameOrigin
-            && ['/v1/models/load', '/v1/models/convert'].includes(target.path)
-            && response.ok
-        ) {
-            response.clone().json().then(payload => {
-                if (!payload?.model) return;
-                const current = latestStatus || { models: { available: [] } };
-                const models = Array.isArray(current.models?.available)
-                    ? [...current.models.available]
-                    : [];
-                const index = models.findIndex(model => model.id === payload.model.id);
-                if (index >= 0) models[index] = payload.model;
-                else models.push(payload.model);
-                scheduleRender({
-                    ...current,
-                    models: { ...(current.models || {}), available: models },
+        } else if (isPreparation) {
+            if (!response.ok) {
+                clearOptimistic(optimisticModelId);
+            } else {
+                response.clone().json().then(payload => {
+                    optimistic.delete(optimisticModelId);
+                    mergeReturnedModel(payload);
+                }).catch(() => {
+                    clearOptimistic(optimisticModelId);
                 });
-            }).catch(() => {});
+            }
         }
         return response;
     };

--- a/tests/test_lifecycle_safety.py
+++ b/tests/test_lifecycle_safety.py
@@ -1,0 +1,118 @@
+"""Regression coverage for cross-operation model lifecycle safety."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import pytest
+
+from app.config import BASE_DIR, Settings
+from app.model_manager import ModelManager
+
+MODEL_ID = "tinyllama-1.1b-chat-fp16"
+
+
+def _manager() -> ModelManager:
+    return ModelManager(
+        Settings(
+            host="127.0.0.1",
+            port=8000,
+            device="CPU",
+            models_file=BASE_DIR / "models.json",
+            models_dir=BASE_DIR / "models" / "openvino",
+            default_model=None,
+            api_key=None,
+            force_mock=True,
+        )
+    )
+
+
+def test_delete_rejects_an_active_conversion_task() -> None:
+    async def scenario() -> None:
+        manager = _manager()
+        release = asyncio.Event()
+        task = asyncio.create_task(release.wait())
+        manager.convert_tasks[MODEL_ID] = task
+        manager._set_status(MODEL_ID, "converting")
+
+        with pytest.raises(ValueError, match="still being prepared"):
+            manager.delete(MODEL_ID)
+
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+        manager.convert_tasks.clear()
+        await manager.shutdown()
+
+    asyncio.run(scenario())
+
+
+def test_latest_load_request_resumes_after_conversion() -> None:
+    async def scenario() -> None:
+        manager = _manager()
+        release = asyncio.Event()
+
+        async def fake_conversion() -> None:
+            try:
+                await release.wait()
+                manager._clear_status(MODEL_ID)
+                manager._set_progress(
+                    MODEL_ID,
+                    "ready",
+                    "Conversion complete.",
+                    percent=100,
+                )
+            finally:
+                manager.convert_tasks.pop(MODEL_ID, None)
+
+        conversion = asyncio.create_task(fake_conversion())
+        manager.convert_tasks[MODEL_ID] = conversion
+        manager._set_status(MODEL_ID, "converting")
+        manager._set_progress(MODEL_ID, "converting", "Converting…", percent=40)
+
+        first = manager.schedule_load(MODEL_ID, "GPU")
+        second = manager.schedule_load(MODEL_ID, "NPU")
+        assert first is conversion
+        assert second is conversion
+        assert "load on NPU" in manager.progress[MODEL_ID]["message"]
+
+        release.set()
+        await conversion
+        await asyncio.sleep(0)
+
+        load_task = manager.load_tasks.get(MODEL_ID)
+        assert load_task is not None
+        await load_task
+        assert manager.devices[MODEL_ID] == "NPU"
+        await manager.shutdown()
+
+    asyncio.run(scenario())
+
+
+def test_shutdown_does_not_start_a_deferred_load() -> None:
+    async def scenario() -> None:
+        manager = _manager()
+        release = asyncio.Event()
+
+        async def fake_conversion() -> None:
+            try:
+                await release.wait()
+            finally:
+                manager.convert_tasks.pop(MODEL_ID, None)
+
+        conversion = asyncio.create_task(fake_conversion())
+        manager.convert_tasks[MODEL_ID] = conversion
+        manager._set_status(MODEL_ID, "converting")
+        manager.schedule_load(MODEL_ID, "NPU")
+
+        shutdown = asyncio.create_task(manager.shutdown())
+        await asyncio.sleep(0)
+        release.set()
+        await shutdown
+        await asyncio.sleep(0)
+
+        assert MODEL_ID not in manager.load_tasks
+        assert MODEL_ID not in manager.engines
+
+    asyncio.run(scenario())

--- a/tests/test_model_load_target.py
+++ b/tests/test_model_load_target.py
@@ -29,20 +29,35 @@ def _client() -> TestClient:
     return TestClient(create_app(settings))
 
 
+def _model_entry(client: TestClient) -> dict:
+    status = client.get("/v1/system/status").json()
+    return next(model for model in status["models"]["available"] if model["id"] == MODEL_ID)
+
+
 def _wait_for_device(client: TestClient, expected_device: str, timeout: float = 10.0) -> dict:
     deadline = time.time() + timeout
     last_entry: dict = {}
     while time.time() < deadline:
-        status = client.get("/v1/system/status").json()
-        last_entry = next(
-            model for model in status["models"]["available"] if model["id"] == MODEL_ID
-        )
+        last_entry = _model_entry(client)
         if last_entry["is_loaded"] and last_entry["device"] == expected_device:
             return last_entry
         time.sleep(0.02)
     raise AssertionError(
         f"{MODEL_ID} did not load on {expected_device}; last status was {last_entry}"
     )
+
+
+def _wait_for_load_task(client: TestClient, timeout: float = 10.0) -> dict:
+    deadline = time.time() + timeout
+    manager = client.app.state.manager
+    last_entry: dict = {}
+    while time.time() < deadline:
+        last_entry = _model_entry(client)
+        task = manager.load_tasks.get(MODEL_ID)
+        if task is None or task.done():
+            return last_entry
+        time.sleep(0.02)
+    raise AssertionError(f"{MODEL_ID} load did not settle; last status was {last_entry}")
 
 
 def test_explicit_npu_load_switches_model_already_loaded_on_gpu() -> None:
@@ -63,6 +78,43 @@ def test_explicit_npu_load_switches_model_already_loaded_on_gpu() -> None:
         entry = _wait_for_device(client, "NPU")
         assert entry["progress"]["phase"] == "ready"
         assert client.app.state.manager.devices[MODEL_ID] == "NPU"
+
+
+def test_failed_device_switch_keeps_the_working_engine_available() -> None:
+    with _client() as client:
+        first = client.post(
+            "/v1/models/load",
+            json={"model": MODEL_ID, "device": "GPU"},
+        )
+        assert first.status_code == 200, first.text
+        _wait_for_device(client, "GPU")
+
+        manager = client.app.state.manager
+        working_engine = manager.engines[MODEL_ID]
+        original_build = manager._build_engine
+
+        def fail_npu_build(
+            model_id: str,
+            device: str,
+            draft_model_path: str | None = None,
+        ) -> MockEngine:
+            if device == "NPU":
+                raise RuntimeError("simulated NPU compiler failure")
+            return original_build(model_id, device, draft_model_path)
+
+        manager._build_engine = fail_npu_build
+        switch = client.post(
+            "/v1/models/load",
+            json={"model": MODEL_ID, "device": "NPU"},
+        )
+        assert switch.status_code == 200, switch.text
+
+        entry = _wait_for_load_task(client)
+        assert entry["is_loaded"] is True
+        assert entry["device"] == "GPU"
+        assert entry["status"] == "loaded"
+        assert "Continuing on GPU" in entry["progress"]["message"]
+        assert manager.engines[MODEL_ID] is working_engine
 
 
 def test_newest_device_request_retargets_in_flight_first_load() -> None:

--- a/tests/test_progress_ui.py
+++ b/tests/test_progress_ui.py
@@ -45,8 +45,27 @@ def test_progress_controller_renders_optimistically_before_first_poll():
     assert "function renderOptimistic" in rendered
     assert "'/v1/models/load'" in rendered
     assert "'/v1/models/convert'" in rendered
+    assert "'/v1/models/download-custom'" in rendered
     assert "Queued ${baseName(base)}" in rendered
     assert "optimistic.set(modelId" in rendered
+
+
+def test_progress_controller_handles_request_objects_and_failed_requests():
+    rendered = inject_multimodal_ui("<html><body></body></html>")
+
+    assert "input?.method" in rendered
+    assert "input instanceof Request" in rendered
+    assert "input.clone().json()" in rendered
+    assert "clearOptimistic(optimisticModelId)" in rendered
+    assert "if (!response.ok)" in rendered
+
+
+def test_progress_controller_resets_retry_state():
+    rendered = inject_multimodal_ui("<html><body></body></html>")
+
+    assert "modelState.delete(modelId)" in rendered
+    assert "reportedStart !== previous.startedAt" in rendered
+    assert "previous.terminal" in rendered
 
 
 def test_progress_controller_uses_text_content_for_server_values():


### PR DESCRIPTION
## Summary

Performs an end-to-end stability and user-experience hardening pass around the app's highest-risk seams: model device switching, concurrent conversion/load/delete operations, shutdown, and browser preparation progress.

## Runtime fixes

- Keep a working loaded engine available until a replacement device engine compiles successfully.
- Preserve the current engine when a requested GPU/NPU/CPU switch fails instead of removing it from runtime state.
- Remove the ineffective ten-minute umbrella timeout around download, conversion, lock draining, and OpenVINO compilation.
- Clean up executor-built engines safely when shutdown cancels an in-flight load task.
- Wait for a busy model without holding the global load lock, allowing unrelated model loads to continue.
- Queue load requests made during conversion and automatically resume the latest requested device afterward.
- Prevent model deletion while loading or conversion is still active.
- Prevent deferred post-conversion loads from starting during shutdown.
- Reset backend progress state for genuinely new preparation attempts.

## Browser UX fixes

- Reset retry progress instead of inheriting a prior failed attempt's elapsed time or near-complete percentage.
- Support preparation requests supplied as `Request` objects, not only string URLs with `init.body`.
- Show immediate progress for custom Hugging Face download/conversion requests.
- Include optimistic custom models before they appear in the next catalog poll.
- Clear optimistic progress immediately on network failures and non-success responses rather than showing ghost activity.
- Preserve the existing single-controller architecture and safe `textContent` rendering.

## Regression coverage

- Failed device switch retains the existing working engine.
- Latest queued device request resumes after conversion.
- Active conversion blocks destructive deletion.
- Shutdown suppresses deferred loads.
- Browser coverage for custom-model progress, Request inputs, failure cleanup, and retry reset semantics.

## Local validation

- Updated Python modules compile successfully.
- Injected browser JavaScript passes `node --check`.
- Full repository CI is requested on this draft PR.