### PR TITLE
Stabilize development branch and browser GUI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   workflow_dispatch:
   push:
-    branches: ["main"]
+    branches: ["main", "development"]
     paths-ignore:
       - "**/*.md"
       - "docs/**"
@@ -174,7 +174,7 @@ jobs:
       - name: Install targeted test dependencies
         run: python -m pip install -e .[dev]
 
-      - name: Run targeted release, evidence, and cancellation tests
+      - name: Run targeted release, evidence, lifecycle, and resilience tests
         env:
           OV_LLM_MOCK: "true"
-        run: pytest tests/test_release_pipeline.py tests/test_release_signing_gate.py tests/test_release_provenance.py tests/test_hardware_advisor.py tests/test_model_library_evidence_identity.py tests/test_model_library_integrity.py tests/test_conversion_cancellation.py
+        run: pytest tests/test_release_pipeline.py tests/test_release_signing_gate.py tests/test_release_provenance.py tests/test_hardware_advisor.py tests/test_model_library_evidence_identity.py tests/test_model_library_integrity.py tests/test_conversion_cancellation.py tests/test_conversion_stream_safety.py tests/test_config_resilience.py tests/test_onboarding_state_resilience.py tests/test_update_checker_resilience.py

--- a/app/config.py
+++ b/app/config.py
@@ -60,6 +60,45 @@ def _bool_env(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in _TRUTHY
 
 
+def _int_env(
+    name: str,
+    default: int,
+    *,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int:
+    """Read a bounded integer environment value without making startup brittle."""
+
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = int(raw.strip())
+    except ValueError:
+        logger.warning("Config: %s=%r is not an integer; using %d", name, raw, default)
+        return default
+    if minimum is not None and value < minimum:
+        logger.warning("Config: %s=%r is below %d; using %d", name, raw, minimum, default)
+        return default
+    if maximum is not None and value > maximum:
+        logger.warning("Config: %s=%r exceeds %d; using %d", name, raw, maximum, default)
+        return default
+    return value
+
+
+def _device_env(name: str = "OV_LLM_DEVICE", default: str = "NPU") -> str:
+    """Read and normalize a device target, falling back after malformed overrides."""
+
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return normalize_device(default)
+    try:
+        return normalize_device(raw)
+    except ValueError:
+        logger.warning("Config: %s=%r is invalid; using %s", name, raw, default)
+        return normalize_device(default)
+
+
 @dataclass(frozen=True)
 class Settings:
     """Immutable runtime settings. Use :meth:`replace` to apply CLI overrides."""
@@ -95,8 +134,8 @@ class Settings:
         runtime_paths = resolve_runtime_paths()
         return cls(
             host=os.environ.get("OV_LLM_HOST", "127.0.0.1"),
-            port=int(os.environ.get("OV_LLM_PORT", "8000")),
-            device=normalize_device(os.environ.get("OV_LLM_DEVICE", "NPU")),
+            port=_int_env("OV_LLM_PORT", 8000, minimum=1, maximum=65535),
+            device=_device_env(),
             models_file=_resolve(
                 os.environ.get("OV_LLM_MODELS_FILE", str(runtime_paths.models_file))
             ),
@@ -115,8 +154,8 @@ class Settings:
             force_mock=_bool_env("OV_LLM_MOCK"),
             auto_convert=_bool_env("OV_LLM_AUTO_CONVERT"),
             cors_origins=os.environ.get("OV_LLM_CORS_ORIGINS", ""),
-            rate_limit=int(os.environ.get("OV_LLM_RATE_LIMIT", "0")),
-            max_request_body_mb=int(os.environ.get("OV_LLM_MAX_REQUEST_BODY_MB", "40")),
+            rate_limit=_int_env("OV_LLM_RATE_LIMIT", 0, minimum=0),
+            max_request_body_mb=_int_env("OV_LLM_MAX_REQUEST_BODY_MB", 40, minimum=1),
         )
 
     def replace(self, **changes) -> Settings:

--- a/app/config.py
+++ b/app/config.py
@@ -13,6 +13,7 @@ from app.chat_guard_ui import install_chat_guard_extension
 from app.chat_queue_ui import install_chat_queue_extension
 from app.desktop_operations_ui import install_desktop_operations_ui_extension
 from app.doctor_ui import install_system_doctor_extension
+from app.gui_stability import install_gui_stability_extension
 from app.header_overflow_ui import install_header_overflow_extension
 from app.model_library_routes import install_model_library_routes_extension
 from app.model_library_ui import install_model_library_ui_extension
@@ -40,6 +41,7 @@ install_progress_ui_extension()
 install_onboarding_ui_extension()
 install_model_library_ui_extension()
 install_desktop_operations_ui_extension()
+install_gui_stability_extension()
 
 logger = logging.getLogger("ov-llm.config")
 _RUNTIME_PATHS = resolve_runtime_paths()

--- a/app/config.py
+++ b/app/config.py
@@ -119,6 +119,7 @@ class Settings:
     max_request_body_mb: int = 40
 
     def __post_init__(self) -> None:
+        from app.conversion_stream_safety import install_conversion_stream_safety
         from app.desktop_model_paths import install_desktop_model_path_extension
         from app.desktop_shutdown_safety import install_desktop_shutdown_safety
         from app.lifecycle_safety import install_model_lifecycle_safety
@@ -126,6 +127,7 @@ class Settings:
 
         install_desktop_model_path_extension()
         install_model_load_target_routing()
+        install_conversion_stream_safety()
         install_model_lifecycle_safety()
         install_desktop_shutdown_safety()
 

--- a/app/conversion_stream_safety.py
+++ b/app/conversion_stream_safety.py
@@ -1,0 +1,61 @@
+"""Keep late converter output from overwriting terminal preparation state."""
+
+from __future__ import annotations
+
+from typing import Any
+
+_INSTALL_FLAG = "_CONVERSION_STREAM_SAFETY_INSTALLED"
+_TERMINAL_STATES = {"cancelled", "error"}
+
+
+async def read_conversion_stream_safely(
+    manager: Any,
+    model_id: str,
+    cfg: Any,
+    stream: Any,
+) -> list[str]:
+    """Drain converter output while preserving cancellation and error state.
+
+    Converter stdout and stderr are consumed by independent tasks. During
+    cancellation those readers can receive a final buffered line after the
+    lifecycle task has already published a terminal state. Continue draining the
+    pipes so the child can exit, but never let late output replace that state.
+    """
+    if stream is None:
+        return []
+
+    lines: list[str] = []
+    while True:
+        raw = await stream.readline()
+        if not raw:
+            break
+        line = manager._sanitize_progress_line(raw.decode(errors="replace"))
+        if not line:
+            continue
+        lines.append(line)
+
+        status = getattr(manager, "status_overrides", {}).get(model_id, {}).get("status")
+        phase = getattr(manager, "progress", {}).get(model_id, {}).get("phase")
+        if status in _TERMINAL_STATES or phase in _TERMINAL_STATES:
+            continue
+
+        next_phase, message, percent = manager._progress_from_converter_line(line, cfg)
+        manager._set_progress(
+            model_id,
+            next_phase,
+            message,
+            percent=percent,
+            append_log=line,
+        )
+    return lines
+
+
+def install_conversion_stream_safety() -> None:
+    from app import model_manager as manager_module
+
+    manager_class = manager_module.ModelManager
+    if getattr(manager_class, _INSTALL_FLAG, False):
+        return
+
+    manager_class._read_conversion_stream = read_conversion_stream_safely
+    setattr(manager_class, _INSTALL_FLAG, True)

--- a/app/gui_stability.py
+++ b/app/gui_stability.py
@@ -1,0 +1,410 @@
+"""Final browser-GUI stability fixes layered over the composed local client."""
+
+from __future__ import annotations
+
+from app import ui_extension
+
+_EXTENSION_ID = "ovllm-gui-stability-extension"
+
+GUI_STABILITY_CSS = r"""
+:root {
+    /* Older search-error markup referenced this token. Keep it mapped to the
+       established destructive color instead of rendering an invalid value. */
+    --danger: var(--red);
+}
+
+.ovllm-gui-stable .modal-card {
+    max-height: 90vh;
+    max-height: calc(100dvh - max(16px, env(safe-area-inset-top)) - max(16px, env(safe-area-inset-bottom)));
+    overscroll-behavior: contain;
+}
+
+.ovllm-gui-stable .modal-form,
+.ovllm-gui-stable .modal-panel,
+.ovllm-gui-stable .form-group,
+.ovllm-gui-stable .search-result-copy {
+    min-width: 0;
+}
+
+.ovllm-gui-stable .search-row input {
+    min-width: 0;
+}
+
+.ovllm-gui-stable .search-result-item {
+    gap: 12px;
+}
+
+.ovllm-gui-stable .search-result-copy {
+    flex: 1 1 auto;
+}
+
+.ovllm-gui-stable .search-result-name {
+    overflow-wrap: anywhere;
+}
+
+.ovllm-gui-stable #hf-search-results[aria-busy="true"] {
+    cursor: progress;
+}
+
+.ovllm-gui-stable #ov-header-more-menu {
+    max-height: min(70dvh, 420px);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+}
+
+@media (max-width: 560px) {
+    .ovllm-gui-stable .modal-overlay {
+        align-items: flex-start;
+        padding: max(8px, env(safe-area-inset-top)) 8px max(8px, env(safe-area-inset-bottom));
+    }
+
+    .ovllm-gui-stable .modal-card {
+        width: 100%;
+        max-height: calc(100dvh - max(16px, env(safe-area-inset-top)) - max(16px, env(safe-area-inset-bottom)));
+    }
+
+    .ovllm-gui-stable .search-row {
+        flex-direction: column;
+    }
+
+    .ovllm-gui-stable .search-row button {
+        width: 100%;
+        min-height: 44px;
+    }
+
+    .ovllm-gui-stable .form-group input,
+    .ovllm-gui-stable .form-group select {
+        font-size: 16px;
+    }
+}
+"""
+
+GUI_STABILITY_JS = r"""(() => {
+'use strict';
+if (window.__ovllmGuiStabilityInstalled) return;
+window.__ovllmGuiStabilityInstalled = true;
+document.documentElement.classList.add('ovllm-gui-stable');
+
+const defer = callback => {
+    if (typeof queueMicrotask === 'function') queueMicrotask(callback);
+    else Promise.resolve().then(callback);
+};
+
+/* Recompute legitimate model/composer disables when the local server comes
+   back. The earlier connection layer intentionally disables controls while
+   offline, but a successful poll did not restore them. */
+const deviceChipElement = document.getElementById('device-chip');
+const deviceLabelElement = document.getElementById('device-label');
+function connectionUnavailable() {
+    const label = String(deviceLabelElement?.textContent || '').trim().toLowerCase();
+    return Boolean(
+        deviceChipElement?.classList.contains('offline') ||
+        label.includes('offline') ||
+        label.includes('auth required') ||
+        label.includes('connecting')
+    );
+}
+let wasUnavailable = connectionUnavailable();
+function repairControlsAfterReconnect() {
+    const unavailable = connectionUnavailable();
+    if (!unavailable && wasUnavailable) {
+        defer(() => {
+            if (typeof updateModelUi === 'function') updateModelUi();
+            if (typeof updateSendButtonState === 'function') updateSendButtonState();
+        });
+    }
+    wasUnavailable = unavailable;
+}
+if (deviceChipElement) {
+    new MutationObserver(repairControlsAfterReconnect).observe(deviceChipElement, {
+        attributes: true,
+        attributeFilter: ['class'],
+        childList: true,
+        subtree: true,
+    });
+}
+repairControlsAfterReconnect();
+
+/* Render remote model-search metadata with text nodes, bound result counts,
+   and cancellation. This prevents stale requests from replacing newer results
+   and avoids treating Hub-provided metadata as HTML. */
+const searchInput = document.getElementById('hf-search-input');
+const searchButton = document.getElementById('hf-search-btn');
+const searchTask = document.getElementById('hf-search-task');
+const searchResults = document.getElementById('hf-search-results');
+let searchController = null;
+
+function setSearchMessage(message, tone = '') {
+    if (!searchResults) return;
+    const node = document.createElement('div');
+    node.className = 'search-empty';
+    if (tone === 'error') node.style.color = 'var(--red)';
+    node.textContent = message;
+    searchResults.replaceChildren(node);
+}
+
+function finiteCount(value) {
+    const number = Number(value);
+    return Number.isFinite(number) && number >= 0 ? Math.round(number) : 0;
+}
+
+function appendSearchMeta(parent, label, value) {
+    const item = document.createElement('span');
+    item.textContent = `${label} ${finiteCount(value).toLocaleString()}`;
+    parent.appendChild(item);
+}
+
+function selectSearchResult(item) {
+    const modelId = String(item?.id || '').trim();
+    if (!modelId) return;
+    const source = document.getElementById('custom-source-model');
+    const backend = document.getElementById('custom-backend');
+    const context = document.getElementById('custom-max-context-len');
+    const name = document.getElementById('custom-model-name');
+    if (source) source.value = modelId;
+    const backendValue = String(item?.backend || '').trim();
+    if (backend && backendValue && Array.from(backend.options).some(option => option.value === backendValue)) {
+        backend.value = backendValue;
+    }
+    if (typeof updateAutofilledFields === 'function') updateAutofilledFields();
+    if (context) {
+        const normalized = modelId.toLowerCase();
+        context.value = normalized.includes('llama-3.2') || normalized.includes('qwen2.5')
+            ? '4096'
+            : normalized.includes('bge') || normalized.includes('embedding')
+            ? '512'
+            : '2048';
+    }
+    if (typeof selectCustomModelTab === 'function') selectCustomModelTab('manual', true);
+    else document.getElementById('tab-btn-manual')?.click();
+    name?.focus();
+}
+
+function renderSafeSearchResults(items) {
+    if (!searchResults) return;
+    searchResults.replaceChildren();
+    const models = Array.isArray(items) ? items.slice(0, 100) : [];
+    if (!models.length) {
+        setSearchMessage('No models found matching your query.');
+        return;
+    }
+    models.forEach(item => {
+        const modelId = String(item?.id || '').trim();
+        if (!modelId) return;
+        const row = document.createElement('div');
+        row.className = 'search-result-item';
+
+        const copy = document.createElement('div');
+        copy.className = 'search-result-copy';
+        const name = document.createElement('div');
+        name.className = 'search-result-name';
+        name.textContent = modelId;
+        const meta = document.createElement('div');
+        meta.className = 'search-result-meta';
+        appendSearchMeta(meta, 'Downloads', item?.downloads);
+        appendSearchMeta(meta, 'Likes', item?.likes);
+        const badge = document.createElement('span');
+        badge.className = 'search-result-badge';
+        badge.textContent = String(item?.pipeline_tag || 'model');
+        meta.appendChild(badge);
+        copy.append(name, meta);
+
+        const select = document.createElement('button');
+        select.type = 'button';
+        select.className = 'search-result-select-btn';
+        select.textContent = 'Select';
+        select.setAttribute('aria-label', `Select ${modelId}`);
+        select.addEventListener('click', () => selectSearchResult(item));
+        row.append(copy, select);
+        searchResults.appendChild(row);
+    });
+    if (!searchResults.children.length) setSearchMessage('No usable models were returned.');
+}
+
+async function runSafeModelSearch() {
+    const query = String(searchInput?.value || '').trim();
+    if (!query || !searchButton || !searchResults) {
+        searchInput?.focus();
+        return;
+    }
+    searchController?.abort();
+    const controller = new AbortController();
+    searchController = controller;
+    const previousLabel = searchButton.textContent;
+    searchButton.disabled = true;
+    searchButton.textContent = 'Searching…';
+    searchResults.setAttribute('aria-busy', 'true');
+    setSearchMessage('Searching Hugging Face Hub…');
+    try {
+        const response = await fetch(
+            `/v1/models/search-hf?query=${encodeURIComponent(query)}&task=${encodeURIComponent(String(searchTask?.value || ''))}`,
+            {
+                headers: typeof authHeaders === 'function' ? authHeaders() : {},
+                signal: controller.signal,
+            },
+        );
+        if (response.status === 401 && typeof handleAuthRequired === 'function') {
+            handleAuthRequired();
+            return;
+        }
+        const body = await response.json().catch(() => null);
+        if (!response.ok) throw new Error(body?.detail || `Search failed (HTTP ${response.status})`);
+        if (!Array.isArray(body)) throw new Error('Search returned an invalid response.');
+        renderSafeSearchResults(body);
+    } catch (error) {
+        if (error?.name === 'AbortError') return;
+        setSearchMessage(`Search failed: ${String(error?.message || error)}`, 'error');
+        if (typeof showToast === 'function') showToast('Model search failed', 'error');
+    } finally {
+        if (searchController === controller) {
+            searchController = null;
+            searchButton.disabled = false;
+            searchButton.textContent = previousLabel || 'Search';
+            searchResults.setAttribute('aria-busy', 'false');
+        }
+    }
+}
+
+searchResults?.setAttribute('role', 'status');
+searchResults?.setAttribute('aria-live', 'polite');
+searchResults?.setAttribute('aria-busy', 'false');
+searchButton?.addEventListener('click', event => {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    void runSafeModelSearch();
+}, true);
+searchInput?.addEventListener('keydown', event => {
+    if (event.key !== 'Enter') return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    void runSafeModelSearch();
+}, true);
+
+/* Keep conditional quantization controls and their displayed value aligned
+   after HTMLFormElement.reset() and whenever the modal is reopened. */
+const customForm = document.getElementById('custom-model-form');
+function syncCustomFormUi() {
+    if (typeof updateInt4Visibility === 'function') updateInt4Visibility();
+    const ratio = document.getElementById('custom-ratio');
+    const ratioValue = document.getElementById('custom-ratio-val');
+    if (ratio && ratioValue) ratioValue.textContent = ratio.value;
+}
+customForm?.addEventListener('reset', () => defer(syncCustomFormUi));
+
+/* If Add Model was activated inside the compact overflow menu, the base modal
+   remembers a button that becomes hidden. Return focus to the visible More
+   Actions trigger instead. */
+const moreTrigger = document.getElementById('ov-header-more-btn');
+let returnFocusToMore = false;
+if (typeof setCustomModelModalOpen === 'function') {
+    const previousSetCustomModelModalOpen = setCustomModelModalOpen;
+    setCustomModelModalOpen = function stableSetCustomModelModalOpen(open, ...args) {
+        if (open) {
+            returnFocusToMore = Boolean(document.activeElement?.closest?.('#ov-header-more-menu'));
+        }
+        const result = previousSetCustomModelModalOpen(open, ...args);
+        defer(syncCustomFormUi);
+        if (!open && returnFocusToMore) {
+            returnFocusToMore = false;
+            defer(() => moreTrigger?.focus());
+        }
+        return result;
+    };
+}
+
+/* Complete keyboard behavior for the ARIA menu and close it when keyboard
+   focus leaves the compact header control. */
+const moreWrap = document.getElementById('ov-header-more-wrap');
+const moreMenu = document.getElementById('ov-header-more-menu');
+function enabledMenuButtons() {
+    if (!moreMenu) return [];
+    return Array.from(moreMenu.querySelectorAll('button:not([disabled])'))
+        .filter(button => button.offsetParent !== null);
+}
+function hideMoreMenu() {
+    if (!moreMenu || !moreTrigger) return;
+    moreMenu.hidden = true;
+    moreTrigger.setAttribute('aria-expanded', 'false');
+}
+moreTrigger?.addEventListener('keydown', event => {
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return;
+    event.preventDefault();
+    if (moreMenu?.hidden) moreTrigger.click();
+    defer(() => {
+        const buttons = enabledMenuButtons();
+        const target = event.key === 'ArrowUp' ? buttons.at(-1) : buttons[0];
+        target?.focus();
+    });
+});
+moreMenu?.addEventListener('keydown', event => {
+    if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) return;
+    const buttons = enabledMenuButtons();
+    if (!buttons.length) return;
+    event.preventDefault();
+    const current = Math.max(0, buttons.indexOf(document.activeElement));
+    const next = event.key === 'Home'
+        ? 0
+        : event.key === 'End'
+        ? buttons.length - 1
+        : event.key === 'ArrowDown'
+        ? (current + 1) % buttons.length
+        : (current - 1 + buttons.length) % buttons.length;
+    buttons[next]?.focus();
+});
+moreWrap?.addEventListener('focusout', () => {
+    window.setTimeout(() => {
+        if (!moreWrap.contains(document.activeElement)) hideMoreMenu();
+    }, 0);
+});
+
+/* Do not force the activity feed back to the newest event while the user is
+   reading older entries. */
+if (typeof renderActivityFeed === 'function') {
+    const previousRenderActivityFeed = renderActivityFeed;
+    renderActivityFeed = function stableRenderActivityFeed(...args) {
+        const list = document.getElementById('activity-list');
+        const priorTop = list?.scrollTop || 0;
+        const distanceFromBottom = list
+            ? list.scrollHeight - list.scrollTop - list.clientHeight
+            : 0;
+        const followLatest = distanceFromBottom < 28;
+        const result = previousRenderActivityFeed(...args);
+        if (list && !followLatest) {
+            requestAnimationFrame(() => {
+                list.scrollTop = Math.min(priorTop, Math.max(0, list.scrollHeight - list.clientHeight));
+            });
+        }
+        return result;
+    };
+}
+
+const toast = document.getElementById('toast');
+toast?.setAttribute('role', 'status');
+toast?.setAttribute('aria-live', 'polite');
+toast?.setAttribute('aria-atomic', 'true');
+syncCustomFormUi();
+})();
+"""
+
+
+def install_gui_stability_extension() -> None:
+    """Compose final GUI recovery, safety, and narrow-screen fixes."""
+
+    if getattr(ui_extension, "_GUI_STABILITY_EXTENSION_INSTALLED", False):
+        return
+    previous_inject = ui_extension.inject_multimodal_ui
+
+    def inject_with_gui_stability(html: str) -> str:
+        html = previous_inject(html)
+        if f'id="{_EXTENSION_ID}"' in html:
+            return html
+        payload = (
+            f'\n<style id="{_EXTENSION_ID}-styles">\n{GUI_STABILITY_CSS}\n</style>\n'
+            f'<script id="{_EXTENSION_ID}">\n{GUI_STABILITY_JS}\n</script>\n'
+        )
+        if "</body>" in html:
+            return html.replace("</body>", f"{payload}</body>", 1)
+        return html + payload
+
+    ui_extension.inject_multimodal_ui = inject_with_gui_stability
+    ui_extension._GUI_STABILITY_EXTENSION_INSTALLED = True

--- a/app/onboarding_state.py
+++ b/app/onboarding_state.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from app.onboarding_models import OnboardingStatusResponse
+from runtime.device_check import normalize_device
 
 SCHEMA_VERSION = 1
 
@@ -35,6 +36,13 @@ def default_state() -> dict[str, Any]:
     }
 
 
+def _normalized_text(value: Any, *, limit: int = 1024) -> str | None:
+    if value in (None, ""):
+        return None
+    text = "".join(char for char in str(value) if char.isprintable()).strip()
+    return text[:limit] or None
+
+
 def migrate_state(raw: Any) -> dict[str, Any]:
     if not isinstance(raw, dict):
         raise ValueError("Onboarding state must be a JSON object.")
@@ -51,15 +59,25 @@ def migrate_state(raw: Any) -> dict[str, Any]:
     state["restart_requested"] = bool(state["restart_requested"])
     for key in (
         "selected_model",
-        "selected_device",
         "actual_device",
         "model_storage_location",
         "last_hardware_fingerprint",
         "last_benchmark_reference",
         "completed_app_version",
     ):
-        value = state.get(key)
-        state[key] = str(value)[:1024] if value not in (None, "") else None
+        state[key] = _normalized_text(state.get(key))
+
+    selected_device = _normalized_text(state.get("selected_device"))
+    if selected_device is not None:
+        try:
+            selected_device = normalize_device(selected_device)
+        except ValueError:
+            # A stale or manually edited device must not crash desktop startup.
+            # Restart first-run selection while retaining models and all other data.
+            selected_device = None
+            state["completed"] = False
+            state["restart_requested"] = True
+    state["selected_device"] = selected_device
     return state
 
 

--- a/app/update_checker.py
+++ b/app/update_checker.py
@@ -91,6 +91,10 @@ class UpdateStore:
         self._write(self.cache_path, cache)
 
 
+def _as_utc(value: datetime) -> datetime:
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
+
+
 def check_due(
     last_checked_at: datetime | None,
     now: datetime,
@@ -98,8 +102,13 @@ def check_due(
 ) -> bool:
     if last_checked_at is None:
         return True
-    normalized = last_checked_at if last_checked_at.tzinfo else last_checked_at.replace(tzinfo=UTC)
-    return now - normalized >= interval
+    current = _as_utc(now)
+    previous = _as_utc(last_checked_at)
+    if previous > current:
+        # A corrected system clock must not suppress updates until a future cache
+        # timestamp is reached.
+        return True
+    return current - previous >= interval
 
 
 def _read_json(response) -> object:
@@ -153,7 +162,7 @@ class UpdateChecker:
         self.installation_mode = installation_mode
         self.opener = opener
         self.now = now
-        self.timeout_seconds = timeout_seconds
+        self.timeout_seconds = max(float(timeout_seconds), 0.1)
 
     def _validated_cached_manifest(self, cache: UpdateCache) -> ReleaseManifest | None:
         if not cache.manifest:
@@ -172,7 +181,7 @@ class UpdateChecker:
         preferences = self.store.load_preferences()
         cache = self.store.load_cache()
         cached_manifest = self._validated_cached_manifest(cache)
-        checked_at = self.now()
+        checked_at = _as_utc(self.now())
         if not preferences.enabled:
             return UpdateCheckResult(status="disabled", checked_at=cache.last_checked_at)
         if not force and not check_due(cache.last_checked_at, checked_at):

--- a/tests/test_config_resilience.py
+++ b/tests/test_config_resilience.py
@@ -1,0 +1,39 @@
+from app.config import Settings, _device_env, _int_env
+
+
+def test_from_env_invalid_numeric_values_fall_back(monkeypatch, caplog):
+    monkeypatch.setenv("OV_LLM_PORT", "not-a-port")
+    monkeypatch.setenv("OV_LLM_RATE_LIMIT", "-2")
+    monkeypatch.setenv("OV_LLM_MAX_REQUEST_BODY_MB", "0")
+
+    settings = Settings.from_env()
+
+    assert settings.port == 8000
+    assert settings.rate_limit == 0
+    assert settings.max_request_body_mb == 40
+    assert "OV_LLM_PORT" in caplog.text
+    assert "OV_LLM_RATE_LIMIT" in caplog.text
+    assert "OV_LLM_MAX_REQUEST_BODY_MB" in caplog.text
+
+
+def test_from_env_invalid_device_falls_back(monkeypatch, caplog):
+    monkeypatch.setenv("OV_LLM_DEVICE", "NPU;DROP")
+
+    settings = Settings.from_env()
+
+    assert settings.device == "NPU"
+    assert "OV_LLM_DEVICE" in caplog.text
+
+
+def test_int_env_enforces_optional_bounds(monkeypatch):
+    monkeypatch.setenv("COUNT", "11")
+    assert _int_env("COUNT", 5, minimum=1, maximum=10) == 5
+    monkeypatch.setenv("COUNT", "0")
+    assert _int_env("COUNT", 5, minimum=1, maximum=10) == 5
+    monkeypatch.setenv("COUNT", "7")
+    assert _int_env("COUNT", 5, minimum=1, maximum=10) == 7
+
+
+def test_device_env_uses_default_for_blank(monkeypatch):
+    monkeypatch.setenv("DEVICE", " ")
+    assert _device_env("DEVICE", "CPU") == "CPU"

--- a/tests/test_conversion_stream_safety.py
+++ b/tests/test_conversion_stream_safety.py
@@ -1,0 +1,54 @@
+import asyncio
+from types import SimpleNamespace
+
+from app.conversion_stream_safety import read_conversion_stream_safely
+
+
+class Stream:
+    def __init__(self, *lines: bytes):
+        self.lines = list(lines) + [b""]
+
+    async def readline(self):
+        return self.lines.pop(0)
+
+
+def test_late_output_does_not_replace_cancelled_state():
+    calls = []
+    manager = SimpleNamespace(
+        status_overrides={"model": {"status": "cancelled"}},
+        progress={"model": {"phase": "cancelled"}},
+        _sanitize_progress_line=lambda value: value.strip(),
+        _progress_from_converter_line=lambda *_args: ("converting", "Converting", 50),
+        _set_progress=lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+    lines = asyncio.run(
+        read_conversion_stream_safely(
+            manager,
+            "model",
+            SimpleNamespace(name="Model"),
+            Stream(b"late output\n"),
+        )
+    )
+    assert lines == ["late output"]
+    assert calls == []
+
+
+def test_active_conversion_still_reports_progress():
+    calls = []
+    manager = SimpleNamespace(
+        status_overrides={"model": {"status": "converting"}},
+        progress={"model": {"phase": "converting"}},
+        _sanitize_progress_line=lambda value: value.strip(),
+        _progress_from_converter_line=lambda *_args: ("converting", "Converting", 50),
+        _set_progress=lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+    asyncio.run(
+        read_conversion_stream_safely(
+            manager,
+            "model",
+            SimpleNamespace(name="Model"),
+            Stream(b"50% converting\n"),
+        )
+    )
+    assert len(calls) == 1
+    assert calls[0][1]["percent"] == 50

--- a/tests/test_gui_stability.py
+++ b/tests/test_gui_stability.py
@@ -1,0 +1,61 @@
+from app.config import Settings  # noqa: F401 - installs composed UI extensions
+from app.gui_stability import GUI_STABILITY_CSS, GUI_STABILITY_JS
+from app.ui_extension import inject_multimodal_ui
+
+
+def test_gui_stability_extension_is_injected_once_and_last() -> None:
+    html = "<html><head></head><body></body></html>"
+
+    rendered = inject_multimodal_ui(html)
+    rendered_twice = inject_multimodal_ui(rendered)
+
+    assert rendered.count('id="ovllm-gui-stability-extension"') == 1
+    assert rendered.count('id="ovllm-gui-stability-extension-styles"') == 1
+    assert rendered_twice.count('id="ovllm-gui-stability-extension"') == 1
+    assert rendered.index('id="ovllm-desktop-operations-extension"') < rendered.index(
+        'id="ovllm-gui-stability-extension"'
+    )
+
+
+def test_reconnect_recomputes_legitimate_control_states() -> None:
+    assert "wasUnavailable" in GUI_STABILITY_JS
+    assert "repairControlsAfterReconnect" in GUI_STABILITY_JS
+    assert "typeof updateModelUi === 'function'" in GUI_STABILITY_JS
+    assert "typeof updateSendButtonState === 'function'" in GUI_STABILITY_JS
+    assert "MutationObserver" in GUI_STABILITY_JS
+
+
+def test_hugging_face_results_are_cancelled_bounded_and_rendered_as_text() -> None:
+    assert "new AbortController()" in GUI_STABILITY_JS
+    assert "items.slice(0, 100)" in GUI_STABILITY_JS
+    assert "event.stopImmediatePropagation()" in GUI_STABILITY_JS
+    assert "badge.textContent" in GUI_STABILITY_JS
+    assert "name.textContent = modelId" in GUI_STABILITY_JS
+    assert "meta.innerHTML" not in GUI_STABILITY_JS
+    assert "Search returned an invalid response" in GUI_STABILITY_JS
+
+
+def test_modal_reset_focus_and_overflow_keyboard_behavior_are_repaired() -> None:
+    assert "customForm?.addEventListener('reset'" in GUI_STABILITY_JS
+    assert "syncCustomFormUi" in GUI_STABILITY_JS
+    assert "returnFocusToMore" in GUI_STABILITY_JS
+    assert "moreTrigger?.focus()" in GUI_STABILITY_JS
+    assert "ArrowDown" in GUI_STABILITY_JS
+    assert "ArrowUp" in GUI_STABILITY_JS
+    assert "moreWrap?.addEventListener('focusout'" in GUI_STABILITY_JS
+
+
+def test_narrow_modal_and_search_layout_use_dynamic_viewport_units() -> None:
+    assert "100dvh" in GUI_STABILITY_CSS
+    assert "env(safe-area-inset-top)" in GUI_STABILITY_CSS
+    assert "env(safe-area-inset-bottom)" in GUI_STABILITY_CSS
+    assert "@media (max-width: 560px)" in GUI_STABILITY_CSS
+    assert ".search-row" in GUI_STABILITY_CSS
+    assert "--danger: var(--red)" in GUI_STABILITY_CSS
+
+
+def test_activity_feed_and_toast_do_not_disrupt_user_context() -> None:
+    assert "followLatest" in GUI_STABILITY_JS
+    assert "priorTop" in GUI_STABILITY_JS
+    assert "aria-live', 'polite'" in GUI_STABILITY_JS
+    assert "aria-atomic', 'true'" in GUI_STABILITY_JS

--- a/tests/test_model_library_integrity.py
+++ b/tests/test_model_library_integrity.py
@@ -302,9 +302,9 @@ def test_advisor_size_failure_does_not_fail_successful_conversion(tmp_path, monk
         ModelDefinitionImportRequest(payload={"models": {"custom-small": _definition()}})
     )
     cfg = manager.catalog["custom-small"]
-    _converted_dir(Path(cfg.model_path))
 
     async def successful_conversion(self, model_id, *_args, **_kwargs):
+        _converted_dir(Path(self.catalog[model_id].model_path))
         self._clear_status(model_id)
 
     import app.model_manager as manager_module

--- a/tests/test_model_load_safety.py
+++ b/tests/test_model_load_safety.py
@@ -70,10 +70,9 @@ def test_recorded_portable_int4_profile_allows_direct_npu(tmp_path) -> None:
         sym=True,
     )
 
-    assert (
-        model_load_safety.safe_load_device(cfg, tmp_path, "NPU", available=["CPU", "NPU"])
-        == "NPU"
-    )
+    assert model_load_safety.safe_load_device(
+        cfg, tmp_path, "NPU", available=["CPU", "NPU"]
+    ) == "NPU"
 
 
 def test_auto_excludes_npu_for_unverified_int4(tmp_path) -> None:

--- a/tests/test_model_load_safety.py
+++ b/tests/test_model_load_safety.py
@@ -70,9 +70,9 @@ def test_recorded_portable_int4_profile_allows_direct_npu(tmp_path) -> None:
         sym=True,
     )
 
-    assert model_load_safety.safe_load_device(
-        cfg, tmp_path, "NPU", available=["CPU", "NPU"]
-    ) == "NPU"
+    assert (
+        model_load_safety.safe_load_device(cfg, tmp_path, "NPU", available=["CPU", "NPU"]) == "NPU"
+    )
 
 
 def test_auto_excludes_npu_for_unverified_int4(tmp_path) -> None:

--- a/tests/test_onboarding_state_resilience.py
+++ b/tests/test_onboarding_state_resilience.py
@@ -1,0 +1,33 @@
+from app.onboarding_state import migrate_state
+
+
+def test_state_migration_normalizes_device_and_sanitizes_text():
+    state = migrate_state(
+        {
+            "completed": True,
+            "selected_model": "  tiny\x00model  ",
+            "selected_device": " auto:npu, gpu, cpu ",
+        }
+    )
+
+    assert state["completed"] is True
+    assert state["selected_model"] == "tinymodel"
+    assert state["selected_device"] == "AUTO:NPU,GPU,CPU"
+
+
+def test_invalid_selected_device_restarts_onboarding_without_dropping_model():
+    state = migrate_state(
+        {
+            "completed": True,
+            "restart_requested": False,
+            "selected_model": "tinyllama-1.1b-chat-fp16",
+            "selected_device": "NPU;invalid",
+            "actual_device": "NPU",
+        }
+    )
+
+    assert state["completed"] is False
+    assert state["restart_requested"] is True
+    assert state["selected_device"] is None
+    assert state["selected_model"] == "tinyllama-1.1b-chat-fp16"
+    assert state["actual_device"] == "NPU"

--- a/tests/test_update_checker_resilience.py
+++ b/tests/test_update_checker_resilience.py
@@ -1,0 +1,38 @@
+from datetime import UTC, datetime, timedelta
+
+from app.update_checker import UpdateChecker, UpdatePreferences, UpdateStore, check_due
+
+
+def test_future_cache_timestamp_is_due_after_clock_correction():
+    now = datetime(2026, 7, 29, 12, tzinfo=UTC)
+
+    assert check_due(now + timedelta(hours=2), now) is True
+
+
+def test_naive_and_aware_timestamps_compare_safely():
+    aware_now = datetime(2026, 7, 29, 12, tzinfo=UTC)
+    naive_previous = datetime(2026, 7, 28, 11)
+
+    assert check_due(naive_previous, aware_now) is True
+
+
+def test_checker_normalizes_naive_clock_and_clamps_timeout(tmp_path):
+    store = UpdateStore(tmp_path)
+    store.save_preferences(UpdatePreferences(enabled=True))
+    calls = []
+
+    def offline(_request, timeout):
+        calls.append(timeout)
+        raise OSError("offline")
+
+    result = UpdateChecker(
+        store=store,
+        installation_mode="installed",
+        opener=offline,
+        now=lambda: datetime(2026, 7, 29, 12),
+        timeout_seconds=0,
+    ).check(force=True)
+
+    assert result.status == "offline"
+    assert result.checked_at == datetime(2026, 7, 29, 12, tzinfo=UTC)
+    assert calls == [0.1]


### PR DESCRIPTION
## What changed

- Preserves terminal conversion progress during cancellation
- Hardens environment configuration and persisted onboarding state
- Handles update-check clock skew and bounded timeouts
- Runs CI on the long-lived `development` branch
- Restores model and composer controls after server reconnect
- Replaces unsafe, race-prone Hugging Face search rendering with bounded DOM-based rendering and request cancellation
- Keeps custom-model form state visually synchronized after reset
- Returns modal focus to the visible overflow trigger
- Adds complete keyboard navigation and dismissal behavior to the compact header menu
- Preserves activity-feed scroll position and improves narrow-screen modal behavior

## Validation

This PR is intended to run the repository's full Linux mock-mode suite, external API contract smoke test, and Windows harness checks before merge.

## Branch policy

Merge into `main` without deleting `development`; `development` remains the long-lived soak-testing branch.