### PR TITLE
chore: trigger obsolete branch cleanup

### DIFF
--- a/.branch-cleanup-trigger
+++ b/.branch-cleanup-trigger
@@ -1,0 +1,1 @@
+Temporary trigger for the trusted obsolete-branch cleanup workflow.

--- a/.branch-cleanup-trigger
+++ b/.branch-cleanup-trigger
@@ -1,2 +1,2 @@
 Temporary trigger for the trusted obsolete-branch cleanup workflow.
-Run after the scoped CI cleanup job was installed on main.
+Run after the effective scoped CI cleanup job was installed on main.

--- a/.branch-cleanup-trigger
+++ b/.branch-cleanup-trigger
@@ -1,1 +1,2 @@
 Temporary trigger for the trusted obsolete-branch cleanup workflow.
+Run after the scoped CI cleanup job was installed on main.


### PR DESCRIPTION
Temporary trusted trigger for deleting the two verified zero-ahead validation branches. Do not merge. The beta branch will be reset to main after the cleanup workflow completes.