### PR TITLE
Merge development into beta without dropping divergent fixes

### DIFF
--- a/app/onboarding_state.py
+++ b/app/onboarding_state.py
@@ -87,6 +87,23 @@ class OnboardingStateStore:
         self.path = Path(path)
         self._lock = threading.RLock()
 
+    def _quarantine_corrupt_state(self) -> None:
+        """Move an unreadable state file aside so recovery is reported only once."""
+
+        backup = self.path.with_suffix(self.path.suffix + ".corrupt")
+        try:
+            backup.parent.mkdir(parents=True, exist_ok=True)
+            self.path.replace(backup)
+            return
+        except OSError:
+            pass
+
+        # Some filesystems or security tools can block an atomic rename. Preserve a
+        # best-effort copy and remove the source only after the backup is durable.
+        with contextlib.suppress(OSError):
+            backup.write_bytes(self.path.read_bytes())
+            self.path.unlink()
+
     def load(self) -> StateLoadResult:
         with self._lock:
             if not self.path.exists():
@@ -95,10 +112,7 @@ class OnboardingStateStore:
                 raw = json.loads(self.path.read_text(encoding="utf-8-sig"))
                 return StateLoadResult(migrate_state(raw))
             except (OSError, TypeError, ValueError):
-                backup = self.path.with_suffix(self.path.suffix + ".corrupt")
-                with contextlib.suppress(OSError):
-                    backup.parent.mkdir(parents=True, exist_ok=True)
-                    backup.write_bytes(self.path.read_bytes())
+                self._quarantine_corrupt_state()
                 return StateLoadResult(
                     default_state(),
                     recovered=True,
@@ -118,9 +132,12 @@ class OnboardingStateStore:
         return normalized
 
     def update(self, **changes: Any) -> dict[str, Any]:
-        current = self.load().state
-        current.update(changes)
-        return self.save(current)
+        # Keep the complete read-modify-write transaction under one reentrant lock.
+        # Separate load/save locks allow concurrent updates to overwrite each other.
+        with self._lock:
+            current = self.load().state
+            current.update(changes)
+            return self.save(current)
 
     def status(self) -> OnboardingStatusResponse:
         loaded = self.load()

--- a/app/request_logging.py
+++ b/app/request_logging.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any
+from urllib.parse import urlsplit
 
 # These endpoints are requested repeatedly by the browser, health probes, or both.
 # Successful fast reads provide little operational value at INFO level, while errors
@@ -25,6 +26,15 @@ _QUIET_METHODS = frozenset({"GET", "HEAD"})
 _RequestLogFields = tuple[str, str, int, float]
 
 
+def _normalize_request_path(value: Any) -> str:
+    """Normalize logged request targets without broadening the quiet-route set."""
+
+    path = urlsplit(str(value)).path or "/"
+    if len(path) > 1:
+        path = path.rstrip("/") or "/"
+    return path
+
+
 def _request_log_fields(record: logging.LogRecord) -> _RequestLogFields | None:
     """Parse the server's structured successful-request log record."""
 
@@ -35,7 +45,12 @@ def _request_log_fields(record: logging.LogRecord) -> _RequestLogFields | None:
         return None
     method, path, status_code, duration_ms = args
     try:
-        return str(method).upper(), str(path), int(status_code), float(duration_ms)
+        return (
+            str(method).upper(),
+            _normalize_request_path(path),
+            int(status_code),
+            float(duration_ms),
+        )
     except (TypeError, ValueError, OverflowError):
         return None
 

--- a/tests/test_onboarding_state.py
+++ b/tests/test_onboarding_state.py
@@ -18,13 +18,19 @@ def test_corrupt_state_restarts_without_touching_models(tmp_path):
     model = tmp_path / "models" / "keep.xml"
     model.parent.mkdir()
     model.write_text("keep", encoding="utf-8")
+    store = OnboardingStateStore(path)
 
-    loaded = OnboardingStateStore(path).load()
+    loaded = store.load()
 
     assert loaded.recovered is True
     assert loaded.state["completed"] is False
     assert model.read_text(encoding="utf-8") == "keep"
     assert path.with_suffix(".json.corrupt").exists()
+    assert not path.exists()
+
+    loaded_again = store.load()
+    assert loaded_again.recovered is False
+    assert loaded_again.state["completed"] is False
 
 
 def test_state_is_written_atomically(tmp_path):
@@ -34,3 +40,15 @@ def test_state_is_written_atomically(tmp_path):
     body = json.loads(path.read_text(encoding="utf-8"))
     assert body["completed"] is True
     assert not path.with_suffix(".json.tmp").exists()
+
+
+def test_update_preserves_existing_fields(tmp_path):
+    path = tmp_path / "state.json"
+    store = OnboardingStateStore(path)
+    store.update(selected_model="tiny", selected_device="CPU")
+
+    state = store.update(completed=True)
+
+    assert state["completed"] is True
+    assert state["selected_model"] == "tiny"
+    assert state["selected_device"] == "CPU"

--- a/tests/test_request_logging.py
+++ b/tests/test_request_logging.py
@@ -24,6 +24,20 @@ def test_fast_successful_polling_requests_are_demoted():
     assert request_filter.filter(_request_record(path="/v1/events")) is False
 
 
+def test_polling_paths_are_normalized_before_matching():
+    request_filter = PollingRequestLogFilter(slow_request_ms=500)
+
+    assert request_filter.filter(_request_record(path="/health/")) is False
+    assert (
+        request_filter.filter(_request_record(path="/v1/events?cursor=17&limit=50")) is False
+    )
+    assert (
+        request_filter.filter(_request_record(path="http://127.0.0.1/v1/models/status?x=1"))
+        is False
+    )
+    assert request_filter.filter(_request_record(path="/v1/events-extra?cursor=17")) is True
+
+
 def test_failures_slow_requests_and_non_polling_routes_remain_visible():
     request_filter = PollingRequestLogFilter(slow_request_ms=500)
 


### PR DESCRIPTION
Conservative integration merge preserving both branch histories.

Verified before opening:
- `development` and `beta` diverged from `12b3f0864747229529e1bda6a4e4e67646e8a576`.
- `development` contains 4 unique commits affecting onboarding-state persistence and request-log sanitization/tests.
- `beta` contains 20 unique commits affecting desktop launch/onboarding hardening, packaged runtime behavior, release scanning, installer contracts, and tests.
- The branch-level changed file sets do not overlap, reducing conflict risk.

Use a merge commit rather than squash/rebase so beta-only work and development commit ancestry are both retained.